### PR TITLE
Add build constraint for syslog so that it doesn't build on windows

### DIFF
--- a/syslog.go
+++ b/syslog.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package metrics
 
 import (


### PR DESCRIPTION
I had trouble building cross-platform binaries that depend on go-metrics since it always tries to build syslog.go even for windows builds. Adding this build constraint avoids building the syslog reporter on windows where it's not available.
