### PR TITLE
fixing typo in sample that was causing panics

### DIFF
--- a/sample.go
+++ b/sample.go
@@ -87,7 +87,7 @@ func (s *ExpDecaySample) Update(v int64) {
 		s.t1 = s.t0.Add(rescaleThreshold)
 		for _, v := range values {
 			v.k = v.k * math.Exp(-s.alpha*float64(s.t0.Sub(t0)))
-			heap.Push(&values, v)
+			heap.Push(&s.values, v)
 		}
 	}
 }


### PR DESCRIPTION
It seems that once you get past the rescaleThreshold size you are going to get panics. It keeps reusing the same array. Looks like a simple typo mistake from your refactoring
