### PR TITLE
Add ObserverEffect and Nil* metrics.

### DIFF
--- a/counter.go
+++ b/counter.go
@@ -15,7 +15,7 @@ type Counter interface {
 
 // Create a new Counter.
 func NewCounter() Counter {
-	if !ObserverEffect {
+	if UseNilMetrics {
 		return NilCounter{}
 	}
 	return &StandardCounter{0}

--- a/ewma.go
+++ b/ewma.go
@@ -19,7 +19,7 @@ type EWMA interface {
 
 // Create a new EWMA with the given alpha.
 func NewEWMA(alpha float64) EWMA {
-	if !ObserverEffect {
+	if UseNilMetrics {
 		return NilEWMA{}
 	}
 	return &StandardEWMA{alpha: alpha}

--- a/gauge.go
+++ b/gauge.go
@@ -13,7 +13,7 @@ type Gauge interface {
 
 // Create a new Gauge.
 func NewGauge() Gauge {
-	if !ObserverEffect {
+	if UseNilMetrics {
 		return NilGauge{}
 	}
 	return &StandardGauge{0}

--- a/healthcheck.go
+++ b/healthcheck.go
@@ -14,7 +14,7 @@ type Healthcheck interface {
 // Create a new Healthcheck, which will use the given function to update
 // its status.
 func NewHealthcheck(f func(Healthcheck)) Healthcheck {
-	if !ObserverEffect {
+	if UseNilMetrics {
 		return NilHealthcheck{}
 	}
 	return &StandardHealthcheck{nil, f}

--- a/histogram.go
+++ b/histogram.go
@@ -28,7 +28,7 @@ type Histogram interface {
 // so that the first value will be both min and max and the variance is flagged
 // for special treatment on its first iteration.
 func NewHistogram(s Sample) Histogram {
-	if !ObserverEffect {
+	if UseNilMetrics {
 		return NilHistogram{}
 	}
 	return &StandardHistogram{

--- a/meter.go
+++ b/meter.go
@@ -19,7 +19,7 @@ type Meter interface {
 // Create a new Meter.  Create the communication channels and start the
 // synchronizing goroutine.
 func NewMeter() Meter {
-	if !ObserverEffect {
+	if UseNilMetrics {
 		return NilMeter{}
 	}
 	m := &StandardMeter{

--- a/metrics.go
+++ b/metrics.go
@@ -5,9 +5,9 @@
 // Coda Hale's original work: <https://github.com/codahale/metrics>
 package metrics
 
-// ObserverEffect is checked by the constructor functions for all of the
-// standard metrics.  If it is false, the metric returned is a stub.
+// UseNilMetrics is checked by the constructor functions for all of the
+// standard metrics.  If it is true, the metric returned is a stub.
 //
 // This global kill-switch helps quantify the observer effect and makes
 // for less cluttered pprof profiles.
-var ObserverEffect bool = true
+var UseNilMetrics bool = false

--- a/sample.go
+++ b/sample.go
@@ -41,7 +41,7 @@ var _ Sample = &ExpDecaySample{}
 // Create a new exponentially-decaying sample with the given reservoir size
 // and alpha.
 func NewExpDecaySample(reservoirSize int, alpha float64) Sample {
-	if !ObserverEffect {
+	if UseNilMetrics {
 		return NilSample{}
 	}
 	s := &ExpDecaySample{
@@ -135,7 +135,7 @@ type UniformSample struct {
 
 // Create a new uniform sample with the given reservoir size.
 func NewUniformSample(reservoirSize int) Sample {
-	if !ObserverEffect {
+	if UseNilMetrics {
 		return NilSample{}
 	}
 	return &UniformSample{reservoirSize: reservoirSize}

--- a/timer.go
+++ b/timer.go
@@ -25,7 +25,7 @@ type Timer interface {
 
 // Create a new timer with the given Histogram and Meter.
 func NewCustomTimer(h Histogram, m Meter) Timer {
-	if !ObserverEffect {
+	if UseNilMetrics {
 		return NilTimer{}
 	}
 	return &StandardTimer{h, m}
@@ -35,7 +35,7 @@ func NewCustomTimer(h Histogram, m Meter) Timer {
 // will use an exponentially-decaying sample with the same reservoir size
 // and alpha as UNIX load averages.
 func NewTimer() Timer {
-	if !ObserverEffect {
+	if UseNilMetrics {
 		return NilTimer{}
 	}
 	return &StandardTimer{


### PR DESCRIPTION
See the comment on ObserverEffect in metrics.go for more.

Note that this changes the signature of New\* for all metrics to return the interface type.  I remember a discussion on the mailing list long ago that convinced me to change the return value of those functions to a concrete type but I can't recall why and this is a good reason to change it back.
