### PR TITLE
Ensure 64-bit alignment for atomic structures

### DIFF
--- a/ewma.go
+++ b/ewma.go
@@ -22,10 +22,10 @@ type EWMA interface {
 // to manage uncounted events.
 type StandardEWMA struct {
 	alpha     float64
-	init      bool
-	mutex     sync.Mutex
 	rate      float64
 	uncounted int64
+	init      bool
+	mutex     sync.Mutex
 }
 
 // Force the compiler to check that StandardEWMA implements EWMA.


### PR DESCRIPTION
Operations against EWMA instances were panic'ing on i386 machines. A bug against
golang was file, and it was closed out noting: it is the caller's responsibility
to arrange for 64-bit alignment of 64-bit words accessed atomically.

This comment ensures such alignment for all instances where atomic is being used
to access their fields (ewma was the only offender).

http://code.google.com/p/go/issues/detail?id=6404
https://github.com/rcrowley/go-metrics/issues/19
