### PR TITLE
Add GetOrRegister method for threadsafe metric registration

### DIFF
--- a/registry_test.go
+++ b/registry_test.go
@@ -34,3 +34,28 @@ func TestRegistry(t *testing.T) {
 		t.Fatal(i)
 	}
 }
+
+func TestGetOrRegister(t *testing.T) {
+	r := NewRegistry()
+
+	// First metric wins with GetOrRegister
+	_ = r.GetOrRegister("foo", NewCounter())
+	m := r.GetOrRegister("foo", NewGauge())
+	if _, ok := m.(Counter); !ok {
+		t.Fatal(m)
+	}
+
+	i := 0
+	r.Each(func(name string, iface interface{}) {
+		i++
+		if name != "foo" {
+			t.Fatal(name)
+		}
+		if _, ok := iface.(Counter); !ok {
+			t.Fatal(iface)
+		}
+	})
+	if i != 1 {
+		t.Fatal(i)
+	}
+}


### PR DESCRIPTION
Advantages over existing metric creation and registration:
- A single statement creates and registers a metric.
- Unused metrics will now be a compiler error (previously all metrics
  would be "used" at least once when registering them).
- The only threadsafe way to dynamically get-or-create metrics without
  wrapping the existing interface.
- Able to get/create metrics locally instead using global variables.
