### PR TITLE
ewma: ensure 64-bit alignment of uncounted

### DIFF
--- a/ewma.go
+++ b/ewma.go
@@ -77,11 +77,11 @@ func (NilEWMA) Update(n int64) {}
 // of uncounted events and processes them on each tick.  It uses the
 // sync/atomic package to manage uncounted events.
 type StandardEWMA struct {
+	uncounted int64		// /!\ this should be the first member to ensure 64-bit alignment
 	alpha     float64
+	rate      float64
 	init      bool
 	mutex     sync.Mutex
-	rate      float64
-	uncounted int64
 }
 
 // Rate returns the moving average rate of events per second.


### PR DESCRIPTION
This bug was already fixed by #20 (and reported in #19) but was rolled
back after merging #17.

`uncounted` has been moved to top with a comment explaining that it
should stay at top. This is not mandatory but this is the easiest way to
ensure a good alignment in the future without taking too much care.

This alignment is required to use atomic functions as explained here:
 http://godoc.org/sync/atomic#pkg-note-bug
