### PR TITLE
Allow lazy instantiation of metric in GetOrRegister.

### DIFF
--- a/counter.go
+++ b/counter.go
@@ -17,7 +17,7 @@ func GetOrRegisterCounter(name string, r Registry) Counter {
 	if nil == r {
 		r = DefaultRegistry
 	}
-	return r.GetOrRegister(name, NewCounter()).(Counter)
+	return r.GetOrRegister(name, NewCounter).(Counter)
 }
 
 // NewCounter constructs a new StandardCounter.

--- a/gauge.go
+++ b/gauge.go
@@ -15,7 +15,7 @@ func GetOrRegisterGauge(name string, r Registry) Gauge {
 	if nil == r {
 		r = DefaultRegistry
 	}
-	return r.GetOrRegister(name, NewGauge()).(Gauge)
+	return r.GetOrRegister(name, NewGauge).(Gauge)
 }
 
 // NewGauge constructs a new StandardGauge.

--- a/histogram.go
+++ b/histogram.go
@@ -22,7 +22,7 @@ func GetOrRegisterHistogram(name string, r Registry, s Sample) Histogram {
 	if nil == r {
 		r = DefaultRegistry
 	}
-	return r.GetOrRegister(name, NewHistogram(s)).(Histogram)
+	return r.GetOrRegister(name, func() Histogram { return NewHistogram(s) }).(Histogram)
 }
 
 // NewHistogram constructs a new StandardHistogram from a Sample.

--- a/meter.go
+++ b/meter.go
@@ -20,7 +20,7 @@ func GetOrRegisterMeter(name string, r Registry) Meter {
 	if nil == r {
 		r = DefaultRegistry
 	}
-	return r.GetOrRegister(name, NewMeter()).(Meter)
+	return r.GetOrRegister(name, NewMeter).(Meter)
 }
 
 // NewMeter constructs a new StandardMeter and launches a goroutine.

--- a/registry_test.go
+++ b/registry_test.go
@@ -71,3 +71,28 @@ func TestRegistryGetOrRegister(t *testing.T) {
 		t.Fatal(i)
 	}
 }
+
+func TestRegistryGetOrRegisterWithLazyInstantiation(t *testing.T) {
+	r := NewRegistry()
+
+	// First metric wins with GetOrRegister
+	_ = r.GetOrRegister("foo", NewCounter)
+	m := r.GetOrRegister("foo", NewGauge)
+	if _, ok := m.(Counter); !ok {
+		t.Fatal(m)
+	}
+
+	i := 0
+	r.Each(func(name string, iface interface{}) {
+		i++
+		if name != "foo" {
+			t.Fatal(name)
+		}
+		if _, ok := iface.(Counter); !ok {
+			t.Fatal(iface)
+		}
+	})
+	if i != 1 {
+		t.Fatal(i)
+	}
+}

--- a/timer.go
+++ b/timer.go
@@ -31,7 +31,7 @@ func GetOrRegisterTimer(name string, r Registry) Timer {
 	if nil == r {
 		r = DefaultRegistry
 	}
-	return r.GetOrRegister(name, NewTimer()).(Timer)
+	return r.GetOrRegister(name, NewTimer).(Timer)
 }
 
 // NewCustomTimer constructs a new StandardTimer from a Histogram and a Meter.


### PR DESCRIPTION
This fixes also memleaks in GetOrRegister\* due to this non-lazy instantiation.

Hi,

I am using your library for an http server that serves thousands of QPS. We came across a memleak: each time a GetOrRegister\* is called, the metric is created, _then_ checked against the registry, and dropped if the metric did indeed exist. This is instantiation is not efficient, but moreover it creates a goroutine that never ends each time, leading to a severe memleak.

Since I call GetOrRegister in each query, I could have work around by not using GetOrRegister and keeping the same metric in a variable, but this patch takes care of the root cause of the problem.

Test case is included. Hope you will be able to merge, thanks.
