### PR TITLE
Fix MarshalJSON to follow other writers pattern.

### DIFF
--- a/json.go
+++ b/json.go
@@ -4,8 +4,9 @@ import "encoding/json"
 
 // MarshalJSON returns a byte slice containing a JSON representation of all
 // the metrics in the Registry.
-func (r StandardRegistry) MarshalJSON() ([]byte, error) {
+func MarshalJSON(r Registry) ([]byte, error) {
 	data := make(map[string]map[string]interface{})
+
 	r.Each(func(name string, i interface{}) {
 		values := make(map[string]interface{})
 		switch metric := i.(type) {


### PR DESCRIPTION
Usage: metrics.MarshalJSON(registry)

See: https://github.com/rcrowley/go-metrics/issues/52
