### PR TITLE
fixed duplicate metric problem at influxDB, on client.WriteSeries

### DIFF
--- a/influxdb/influxdb.go
+++ b/influxdb/influxdb.go
@@ -102,10 +102,10 @@ func send(r metrics.Registry, client *influxClient.Client) error {
 				},
 			})
 		}
-		if err := client.WriteSeries(series); err != nil {
-			log.Println(err)
-		}
 	})
+	if err := client.WriteSeries(series); err != nil {
+		log.Println(err)
+	}
 	return nil
 }
 


### PR DESCRIPTION
when emitting metrics to influxDB, client.WriteSeries is invoked multiple times.

excerpt from AS-IS

```
2014/05/20 17:51:42 registry: &{map[foo:0xc2100001b8 bar:0xc2100001c0] {0 0}}
data: [{"name":"foo.count","columns":["time","count"],"points":[[1400575902627,58]]}]
data: [{"name":"foo.count","columns":["time","count"],"points":[[1400575902627,58]]},{"name":"bar.value","columns":["time","value"],"points":[[1400575902637,58]]}]
```

expected behavior

```
2014/05/20 17:51:42 registry: &{map[foo:0xc2100001b8 bar:0xc2100001c0] {0 0}}
data: [{"name":"foo.count","columns":["time","count"],"points":[[1400575902627,58]]},{"name":"bar.value","columns":["time","value"],"points":[[1400575902637,58]]}]
```
