### PR TITLE
Use a time.Ticker instead of the time.Sleep

### DIFF
--- a/json.go
+++ b/json.go
@@ -71,9 +71,8 @@ func (r StandardRegistry) MarshalJSON() ([]byte, error) {
 // WriteJSON writes metrics from the given registry  periodically to the
 // specified io.Writer as JSON.
 func WriteJSON(r Registry, d time.Duration, w io.Writer) {
-	for {
+	for _ = range time.Tick(d) {
 		WriteJSONOnce(r, w)
-		time.Sleep(d)
 	}
 }
 


### PR DESCRIPTION
This also prevents writing the metrics immediately after calling `WriteJSON`, which would likely be an empty registry in the beginning.
