### PR TITLE
Use [0,1] value for Librato percentile in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ go librato.Librato(metrics.DefaultRegistry,
     "example@example.com", // account owner email address
     "token",               // Librato API token
     "hostname",            // source
-    []float64{95},         // precentiles to send
+    []float64{0.95},       // precentiles to send
     time.Millisecond,      // time unit
 )
 ```


### PR DESCRIPTION
I think this expects a value `[0,1]`, right?
