### PR TITLE
don't report zero counters. it's expensive.

### DIFF
--- a/librato/librato.go
+++ b/librato/librato.go
@@ -2,11 +2,12 @@ package librato
 
 import (
 	"fmt"
-	"github.com/rcrowley/go-metrics"
 	"log"
 	"math"
 	"regexp"
 	"time"
+
+	"github.com/rcrowley/go-metrics"
 )
 
 // a regexp for extracting the unit from time.Duration.String
@@ -87,14 +88,16 @@ func (self *Reporter) BuildRequest(now time.Time, r metrics.Registry) (snapshot 
 		measurement[Period] = self.Interval.Seconds()
 		switch m := metric.(type) {
 		case metrics.Counter:
-			measurement[Name] = fmt.Sprintf("%s.%s", name, "count")
-			measurement[Value] = float64(m.Count())
-			measurement[Attributes] = map[string]interface{}{
-				DisplayUnitsLong:  Operations,
-				DisplayUnitsShort: OperationsShort,
-				DisplayMin:        "0",
+			if m.Count() > 0 {
+				measurement[Name] = fmt.Sprintf("%s.%s", name, "count")
+				measurement[Value] = float64(m.Count())
+				measurement[Attributes] = map[string]interface{}{
+					DisplayUnitsLong:  Operations,
+					DisplayUnitsShort: OperationsShort,
+					DisplayMin:        "0",
+				}
+				snapshot.Counters = append(snapshot.Counters, measurement)
 			}
-			snapshot.Counters = append(snapshot.Counters, measurement)
 		case metrics.Gauge:
 			measurement[Name] = name
 			measurement[Value] = float64(m.Value())


### PR DESCRIPTION
Things like `tigertonic.CountedByStatus` and `tigertonic.CountedByStatusXX` get really expensive when you have lots of endpoints that only return 1 or 2 of those status codes or status code ranges. The rest of the codes/ranges dutifully log 0's into Librato and out of your wallet.

Additionally, I think the code under `case metrics.Histogram` (now line 109) should be checked. To avoid sending empty updates, should the correct behavior be to get the `Sample` first and check that `sample.Count()` is greater than 0, instead of doing so on the histogram directly?
