### PR TITLE
add Sum() to Timer and Histogram

### DIFF
--- a/histogram.go
+++ b/histogram.go
@@ -4,6 +4,7 @@ package metrics
 type Histogram interface {
 	Clear()
 	Count() int64
+	Sum() int64
 	Max() int64
 	Mean() float64
 	Min() int64
@@ -58,6 +59,10 @@ func (*HistogramSnapshot) Clear() {
 // taken.
 func (h *HistogramSnapshot) Count() int64 { return h.sample.Count() }
 
+// Sum returns the sum in the sample at the time the snapshot was
+// taken.
+func (h *HistogramSnapshot) Sum() int64 { return h.sample.Sum() }
+
 // Max returns the maximum value in the sample at the time the snapshot was
 // taken.
 func (h *HistogramSnapshot) Max() int64 { return h.sample.Max() }
@@ -109,6 +114,9 @@ func (NilHistogram) Clear() {}
 // Count is a no-op.
 func (NilHistogram) Count() int64 { return 0 }
 
+// Sum is a no-op.
+func (NilHistogram) Sum() int64 { return 0 }
+
 // Max is a no-op.
 func (NilHistogram) Max() int64 { return 0 }
 
@@ -153,6 +161,9 @@ func (h *StandardHistogram) Clear() { h.sample.Clear() }
 // Count returns the number of samples recorded since the histogram was last
 // cleared.
 func (h *StandardHistogram) Count() int64 { return h.sample.Count() }
+
+// Sum returns the sum in the sample.
+func (h *StandardHistogram) Sum() int64 { return h.sample.Sum() }
 
 // Max returns the maximum value in the sample.
 func (h *StandardHistogram) Max() int64 { return h.sample.Max() }

--- a/timer.go
+++ b/timer.go
@@ -8,6 +8,7 @@ import (
 // Timers capture the duration and rate of events.
 type Timer interface {
 	Count() int64
+	Sum() int64
 	Max() int64
 	Mean() float64
 	Min() int64
@@ -76,6 +77,9 @@ type NilTimer struct {
 // Count is a no-op.
 func (NilTimer) Count() int64 { return 0 }
 
+// Sum is a no-op.
+func (NilTimer) Sum() int64 { return 0 }
+
 // Max is a no-op.
 func (NilTimer) Max() int64 { return 0 }
 
@@ -134,6 +138,11 @@ type StandardTimer struct {
 // Count returns the number of events recorded.
 func (t *StandardTimer) Count() int64 {
 	return t.histogram.Count()
+}
+
+// Sum returns the sum in the sample.
+func (t *StandardTimer) Sum() int64 {
+	return t.histogram.Sum()
 }
 
 // Max returns the maximum value in the sample.
@@ -234,6 +243,9 @@ type TimerSnapshot struct {
 // Count returns the number of events recorded at the time the snapshot was
 // taken.
 func (t *TimerSnapshot) Count() int64 { return t.histogram.Count() }
+
+// Sum returns the sum at the time the snapshot was taken.
+func (t *TimerSnapshot) Sum() int64 { return t.histogram.Sum() }
 
 // Max returns the maximum value at the time the snapshot was taken.
 func (t *TimerSnapshot) Max() int64 { return t.histogram.Max() }


### PR DESCRIPTION
I want `Sum()` for Timer, so added. Are there any reasons that Timer have not had `Sum()` method?
