### PR TITLE
Specialize expDecaySampleHeap to reduce allocations

### DIFF
--- a/sample.go
+++ b/sample.go
@@ -535,6 +535,7 @@ func newExpDecaySampleHeap(reservoirSize int) *expDecaySampleHeap {
 }
 
 // expDecaySampleHeap is a min-heap of expDecaySamples.
+// The internal implementation is copied from the standard library's container/heap
 type expDecaySampleHeap struct {
 	s []expDecaySample
 }


### PR DESCRIPTION
Fixes #77 
