### PR TITLE
Add Sum in Histogram librato measurement

### DIFF
--- a/librato/librato.go
+++ b/librato/librato.go
@@ -116,6 +116,7 @@ func (self *Reporter) BuildRequest(now time.Time, r metrics.Registry) (snapshot 
 				measurement[Count] = uint64(s.Count())
 				measurement[Max] = float64(s.Max())
 				measurement[Min] = float64(s.Min())
+				measurement[Sum] = float64(s.Sum())
 				measurement[SumSquares] = sumSquares(s)
 				gauges[0] = measurement
 				for i, p := range self.Percentiles {


### PR DESCRIPTION
Gauge sum is required in librato API when count is present :

> If count is set, then sum must also be set in order to calculate an average value for the recorded metric measurement. 

from [Gauge Specific Parameters](http://dev.librato.com/v1/post/metrics)

Without this attribute, the request is refused : 

```
2014/10/12 16:59:54 ERROR sending metrics to librato Unable to post to Librato: 400 400 Bad Request {"errors":{"params":{"sum":["is required"],"name":"buffer.SizeHistory.hist"}}}
```
