### PR TITLE
Fix registry race caused by copying a sync.Mutex

### DIFF
--- a/json.go
+++ b/json.go
@@ -8,7 +8,7 @@ import (
 
 // MarshalJSON returns a byte slice containing a JSON representation of all
 // the metrics in the Registry.
-func (r StandardRegistry) MarshalJSON() ([]byte, error) {
+func (r *StandardRegistry) MarshalJSON() ([]byte, error) {
 	data := make(map[string]map[string]interface{})
 	r.Each(func(name string, i interface{}) {
 		values := make(map[string]interface{})


### PR DESCRIPTION
StandardRegistry.MarshalJSON receiver needs to be a pointer to avoid copy.