### PR TITLE
Data race between StandardRegistry.{Register,Each}

### DIFF
--- a/influxdb/influxdb.go
+++ b/influxdb/influxdb.go
@@ -46,7 +46,7 @@ func Send(r metrics.Registry, client *influxClient.Client, database string) erro
 	series := []influxClient.Point{}
 
 	r.Each(func(name string, i interface{}) {
-		now := influxClient.Timestamp(time.Now()) // getCurrentTime()
+		now := time.Now() // getCurrentTime()
 		switch metric := i.(type) {
 		case metrics.Counter:
 			series = append(series, influxClient.Point{
@@ -127,7 +127,7 @@ func Send(r metrics.Registry, client *influxClient.Client, database string) erro
 			})
 		}
 	})
-	if _, err := client.Write(influxClient.Write{
+	if _, err := client.Write(influxClient.BatchPoints{
 		Database: database,
 		Points:   series,
 	}); err != nil {

--- a/influxdb/influxdb.go
+++ b/influxdb/influxdb.go
@@ -50,24 +50,24 @@ func Send(r metrics.Registry, client *influxClient.Client, database string) erro
 		switch metric := i.(type) {
 		case metrics.Counter:
 			series = append(series, influxClient.Point{
-				Name:      fmt.Sprintf("%s.count", name),
-				Timestamp: now,
+				Name: fmt.Sprintf("%s.count", name),
+				Time: now,
 				Fields: map[string]interface{}{
 					"count": metric.Count(),
 				},
 			})
 		case metrics.Gauge:
 			series = append(series, influxClient.Point{
-				Name:      fmt.Sprintf("%s.value", name),
-				Timestamp: now,
+				Name: fmt.Sprintf("%s.value", name),
+				Time: now,
 				Fields: map[string]interface{}{
 					"value": metric.Value(),
 				},
 			})
 		case metrics.GaugeFloat64:
 			series = append(series, influxClient.Point{
-				Name:      fmt.Sprintf("%s.value", name),
-				Timestamp: now,
+				Name: fmt.Sprintf("%s.value", name),
+				Time: now,
 				Fields: map[string]interface{}{
 					"value": metric.Value(),
 				},
@@ -76,8 +76,8 @@ func Send(r metrics.Registry, client *influxClient.Client, database string) erro
 			h := metric.Snapshot()
 			ps := h.Percentiles([]float64{0.5, 0.75, 0.95, 0.99, 0.999})
 			series = append(series, influxClient.Point{
-				Name:      fmt.Sprintf("%s.histogram", name),
-				Timestamp: now,
+				Name: fmt.Sprintf("%s.histogram", name),
+				Time: now,
 				Fields: map[string]interface{}{
 					"count":          h.Count(),
 					"min":            h.Min(),

--- a/influxdb/influxdb.go
+++ b/influxdb/influxdb.go
@@ -52,7 +52,7 @@ func Send(r metrics.Registry, client *influxClient.Client, database string) erro
 			series = append(series, influxClient.Point{
 				Name:      fmt.Sprintf("%s.count", name),
 				Timestamp: now,
-				Values: map[string]interface{}{
+				Fields: map[string]interface{}{
 					"count": metric.Count(),
 				},
 			})
@@ -60,7 +60,7 @@ func Send(r metrics.Registry, client *influxClient.Client, database string) erro
 			series = append(series, influxClient.Point{
 				Name:      fmt.Sprintf("%s.value", name),
 				Timestamp: now,
-				Values: map[string]interface{}{
+				Fields: map[string]interface{}{
 					"value": metric.Value(),
 				},
 			})
@@ -68,7 +68,7 @@ func Send(r metrics.Registry, client *influxClient.Client, database string) erro
 			series = append(series, influxClient.Point{
 				Name:      fmt.Sprintf("%s.value", name),
 				Timestamp: now,
-				Values: map[string]interface{}{
+				Fields: map[string]interface{}{
 					"value": metric.Value(),
 				},
 			})
@@ -78,7 +78,7 @@ func Send(r metrics.Registry, client *influxClient.Client, database string) erro
 			series = append(series, influxClient.Point{
 				Name:      fmt.Sprintf("%s.histogram", name),
 				Timestamp: now,
-				Values: map[string]interface{}{
+				Fields: map[string]interface{}{
 					"count":          h.Count(),
 					"min":            h.Min(),
 					"max":            h.Max(),
@@ -95,7 +95,7 @@ func Send(r metrics.Registry, client *influxClient.Client, database string) erro
 			m := metric.Snapshot()
 			series = append(series, influxClient.Point{
 				Name: fmt.Sprintf("%s.meter", name),
-				Values: map[string]interface{}{
+				Fields: map[string]interface{}{
 					"count":          m.Count(),
 					"one-minute":     m.Rate1(),
 					"five-minute":    m.Rate5(),
@@ -108,7 +108,7 @@ func Send(r metrics.Registry, client *influxClient.Client, database string) erro
 			ps := h.Percentiles([]float64{0.5, 0.75, 0.95, 0.99, 0.999})
 			series = append(series, influxClient.Point{
 				Name: fmt.Sprintf("%s.timer", name),
-				Values: map[string]interface{}{
+				Fields: map[string]interface{}{
 					"count":          h.Count(),
 					"min":            h.Min(),
 					"max":            h.Max(),

--- a/influxdb/influxdb.go
+++ b/influxdb/influxdb.go
@@ -5,6 +5,7 @@ import (
 	influxClient "github.com/influxdb/influxdb/client"
 	"github.com/rcrowley/go-metrics"
 	"log"
+	"net/url"
 	"time"
 )
 
@@ -16,94 +17,120 @@ type Config struct {
 }
 
 func Influxdb(r metrics.Registry, d time.Duration, config *Config) {
-	client, err := influxClient.NewClient(&influxClient.ClientConfig{
-		Host:     config.Host,
-		Database: config.Database,
-		Username: config.Username,
-		Password: config.Password,
-	})
+	client, err := NewClient(config)
 	if err != nil {
 		log.Println(err)
 		return
 	}
 
 	for _ = range time.Tick(d) {
-		if err := send(r, client); err != nil {
+		if err := Send(r, client, config.Database); err != nil {
 			log.Println(err)
 		}
 	}
 }
 
-func send(r metrics.Registry, client *influxClient.Client) error {
-	series := []*influxClient.Series{}
+func NewClient(config *Config) (*influxClient.Client, error) {
+	URL, err := url.Parse(config.Host)
+	if err != nil {
+		return nil, err
+	}
+	return influxClient.NewClient(influxClient.Config{
+		URL:      *URL,
+		Username: config.Username,
+		Password: config.Password,
+	})
+}
+
+func Send(r metrics.Registry, client *influxClient.Client, database string) error {
+	series := []influxClient.Point{}
 
 	r.Each(func(name string, i interface{}) {
-		now := getCurrentTime()
+		now := influxClient.Timestamp(time.Now()) // getCurrentTime()
 		switch metric := i.(type) {
 		case metrics.Counter:
-			series = append(series, &influxClient.Series{
-				Name:    fmt.Sprintf("%s.count", name),
-				Columns: []string{"time", "count"},
-				Points: [][]interface{}{
-					{now, metric.Count()},
+			series = append(series, influxClient.Point{
+				Name:      fmt.Sprintf("%s.count", name),
+				Timestamp: now,
+				Values: map[string]interface{}{
+					"count": metric.Count(),
 				},
 			})
 		case metrics.Gauge:
-			series = append(series, &influxClient.Series{
-				Name:    fmt.Sprintf("%s.value", name),
-				Columns: []string{"time", "value"},
-				Points: [][]interface{}{
-					{now, metric.Value()},
+			series = append(series, influxClient.Point{
+				Name:      fmt.Sprintf("%s.value", name),
+				Timestamp: now,
+				Values: map[string]interface{}{
+					"value": metric.Value(),
 				},
 			})
 		case metrics.GaugeFloat64:
-			series = append(series, &influxClient.Series{
-				Name:    fmt.Sprintf("%s.value", name),
-				Columns: []string{"time", "value"},
-				Points: [][]interface{}{
-					{now, metric.Value()},
+			series = append(series, influxClient.Point{
+				Name:      fmt.Sprintf("%s.value", name),
+				Timestamp: now,
+				Values: map[string]interface{}{
+					"value": metric.Value(),
 				},
 			})
 		case metrics.Histogram:
 			h := metric.Snapshot()
 			ps := h.Percentiles([]float64{0.5, 0.75, 0.95, 0.99, 0.999})
-			series = append(series, &influxClient.Series{
-				Name: fmt.Sprintf("%s.histogram", name),
-				Columns: []string{"time", "count", "min", "max", "mean", "std-dev",
-					"50-percentile", "75-percentile", "95-percentile",
-					"99-percentile", "999-percentile"},
-				Points: [][]interface{}{
-					{now, h.Count(), h.Min(), h.Max(), h.Mean(), h.StdDev(),
-						ps[0], ps[1], ps[2], ps[3], ps[4]},
+			series = append(series, influxClient.Point{
+				Name:      fmt.Sprintf("%s.histogram", name),
+				Timestamp: now,
+				Values: map[string]interface{}{
+					"count":          h.Count(),
+					"min":            h.Min(),
+					"max":            h.Max(),
+					"mean":           h.Mean(),
+					"std-dev":        h.StdDev(),
+					"50-percentile":  ps[0],
+					"75-percentile":  ps[1],
+					"95-percentile":  ps[2],
+					"99-percentile":  ps[3],
+					"999-percentile": ps[4],
 				},
 			})
 		case metrics.Meter:
 			m := metric.Snapshot()
-			series = append(series, &influxClient.Series{
+			series = append(series, influxClient.Point{
 				Name: fmt.Sprintf("%s.meter", name),
-				Columns: []string{"count", "one-minute",
-					"five-minute", "fifteen-minute", "mean"},
-				Points: [][]interface{}{
-					{m.Count(), m.Rate1(), m.Rate5(), m.Rate15(), m.RateMean()},
+				Values: map[string]interface{}{
+					"count":          m.Count(),
+					"one-minute":     m.Rate1(),
+					"five-minute":    m.Rate5(),
+					"fifteen-minute": m.Rate15(),
+					"mean":           m.RateMean(),
 				},
 			})
 		case metrics.Timer:
 			h := metric.Snapshot()
 			ps := h.Percentiles([]float64{0.5, 0.75, 0.95, 0.99, 0.999})
-			series = append(series, &influxClient.Series{
+			series = append(series, influxClient.Point{
 				Name: fmt.Sprintf("%s.timer", name),
-				Columns: []string{"count", "min", "max", "mean", "std-dev",
-					"50-percentile", "75-percentile", "95-percentile",
-					"99-percentile", "999-percentile", "one-minute", "five-minute", "fifteen-minute", "mean-rate"},
-				Points: [][]interface{}{
-					{h.Count(), h.Min(), h.Max(), h.Mean(), h.StdDev(),
-						ps[0], ps[1], ps[2], ps[3], ps[4],
-						h.Rate1(), h.Rate5(), h.Rate15(), h.RateMean()},
+				Values: map[string]interface{}{
+					"count":          h.Count(),
+					"min":            h.Min(),
+					"max":            h.Max(),
+					"mean":           h.Mean(),
+					"std-dev":        h.StdDev(),
+					"50-percentile":  ps[0],
+					"75-percentile":  ps[1],
+					"95-percentile":  ps[2],
+					"99-percentile":  ps[3],
+					"999-percentile": ps[4],
+					"one-minute":     h.Rate1(),
+					"five-minute":    h.Rate5(),
+					"fifteen-minute": h.Rate15(),
+					"mean-rate":      h.RateMean(),
 				},
 			})
 		}
 	})
-	if err := client.WriteSeries(series); err != nil {
+	if _, err := client.Write(influxClient.Write{
+		Database: database,
+		Points:   series,
+	}); err != nil {
 		log.Println(err)
 	}
 	return nil

--- a/registry.go
+++ b/registry.go
@@ -136,9 +136,9 @@ func (r *StandardRegistry) register(name string, i interface{}) error {
 }
 
 func (r *StandardRegistry) registered() map[string]interface{} {
-	metrics := make(map[string]interface{}, len(r.metrics))
 	r.mutex.Lock()
 	defer r.mutex.Unlock()
+	metrics := make(map[string]interface{}, len(r.metrics))
 	for name, i := range r.metrics {
 		metrics[name] = i
 	}


### PR DESCRIPTION
[registry.go:139](https://github.com/rcrowley/go-metrics/blob/master/registry.go#L139) does `len(r.metrics)` before the mutex lock.

The data race observed:
```
==================
WARNING: DATA RACE
Read by goroutine 19:
  github.com/rcrowley/go-metrics.(*StandardRegistry).registered()
      /Users/rz/.gvm/pkgsets/go1.3.3/ostent/src/github.com/rcrowley/go-metrics/registry.go:141 +0x63
  github.com/rcrowley/go-metrics.(*StandardRegistry).Each()
      /Users/rz/.gvm/pkgsets/go1.3.3/ostent/src/github.com/rcrowley/go-metrics/registry.go:65 +0x42
  github.com/rcrowley/go-metrics/influxdb.send()
      /Users/rz/.gvm/pkgsets/go1.3.3/ostent/src/github.com/rcrowley/go-metrics/influxdb/influxdb.go:105 +0x13a
  github.com/rcrowley/go-metrics/influxdb.Influxdb()
      /Users/rz/.gvm/pkgsets/go1.3.3/ostent/src/github.com/rcrowley/go-metrics/influxdb/influxdb.go:31 +0x334

Previous write by goroutine 32:
  runtime.mapassign1()
      /private/var/folders/00/0sdwh000h01000cxqpysvccm0035qk/T/makerelease910109054/go/src/pkg/runtime/hashmap.goc:925 +0x0
  github.com/rcrowley/go-metrics.(*StandardRegistry).register()
      /Users/rz/.gvm/pkgsets/go1.3.3/ostent/src/github.com/rcrowley/go-metrics/registry.go:135 +0x222
  github.com/rcrowley/go-metrics.(*StandardRegistry).Register()
      /Users/rz/.gvm/pkgsets/go1.3.3/ostent/src/github.com/rcrowley/go-metrics/registry.go:99 +0xc1
  github.com/rcrowley/go-metrics.NewRegisteredGauge()
      /Users/rz/.gvm/pkgsets/go1.3.3/ostent/src/github.com/rcrowley/go-metrics/gauge.go:35 +0x176
  github.com/ostrost/ostent/types.NewGaugeDiff()
      /Users/rz/.gvm/pkgsets/go1.3.3/ostent/src/github.com/ostrost/ostent/types/types.go:442 +0x7d
  github.com/ostrost/ostent.(*IndexRegistry).GetOrRegisterPrivateInterface()
      /Users/rz/.gvm/pkgsets/go1.3.3/ostent/src/github.com/ostrost/ostent/index.go:338 +0x5b6
  github.com/ostrost/ostent.(*IndexRegistry).UpdateIFdata()
      /Users/rz/.gvm/pkgsets/go1.3.3/ostent/src/github.com/ostrost/ostent/index.go:640 +0x97
  github.com/ostrost/ostent.getInterfaces()
      /Users/rz/.gvm/pkgsets/go1.3.3/ostent/src/github.com/ostrost/ostent/interfaces.go:59 +0x296

Goroutine 19 (running) created at:
  github.com/ostrost/ostent/commands.func·007()
      /Users/rz/.gvm/pkgsets/go1.3.3/ostent/src/github.com/ostrost/ostent/commands/influxdb.go:43 +0x22b

Goroutine 32 (finished) created at:
  github.com/ostrost/ostent.(*last).collect()
      /Users/rz/.gvm/pkgsets/go1.3.3/ostent/src/github.com/ostrost/ostent/index.go:209 +0x285
  github.com/ostrost/ostent.func·018()
      /Users/rz/.gvm/pkgsets/go1.3.3/ostent/src/github.com/ostrost/ostent/ws.go:53 +0x156
==================
```