### PR TITLE
add windowsample

### DIFF
--- a/sample.go
+++ b/sample.go
@@ -667,9 +667,8 @@ func (w *WindowSample) Size() int {
 func (w *WindowSample) Snapshot() Sample {
 	w.mutex.Lock()
 	defer w.mutex.Unlock()
-	values := w.Values()
-	vals := make([]int64, len(values))
-	copy(vals, values)
+	values := make([]int64, len(w.values))
+	copy(values, w.values)
 	w.values = make([]int64, 0)
 	return &SampleSnapshot{
 		count:  int64(len(values)),
@@ -698,9 +697,9 @@ func (w *WindowSample) Update(v int64) {
 func (w *WindowSample) Values() []int64 {
 	w.mutex.Lock()
 	defer w.mutex.Unlock()
-	val := make([]int64, len(w.values))
-	copy(val, w.values)
-	return val
+	values := make([]int64, len(w.values))
+	copy(values, w.values)
+	return values
 }
 
 // Variance returns the variance of the values in the sample.


### PR DESCRIPTION
a very simple sampler, just retains all data since the last snapshot. the more data between snapshots, the more data it needs to process.
don't run multiple independent reporters that take independent snapshots or you'll get unexpected results, as documented.

with those caveats in mind, it seems to work fine for me.
we might want to address those issues later though.  i just needed to get something working for use case #10 
we could also implement the sliding window variant of the forward decay filter, but that was a bit over my head for now.
