### PR TITLE
make log period more explicit

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ t.Update(47)
 Periodically log every metric in human-readable form to standard error:
 
 ```go
-go metrics.Log(metrics.DefaultRegistry, 60e9, log.New(os.Stderr, "metrics: ", log.Lmicroseconds))
+go metrics.Log(metrics.DefaultRegistry, 5 * time.Second, log.New(os.Stderr, "metrics: ", log.Lmicroseconds))
 ```
 
 Periodically log every metric in slightly-more-parseable form to syslog:


### PR DESCRIPTION
Updates the periodically log example in README.md to pass an explicit `time.Duration` value instead of the value `60e9`.