### PR TITLE
Metrics URL fixed in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 go-metrics
 ==========
 
-Go port of Coda Hale's Metrics library: <https://github.com/codahale/metrics>.
+Go port of Coda Hale's Metrics library: <https://github.com/dropwizard/metrics>.
 
 Documentation: <http://godoc.org/github.com/rcrowley/go-metrics>.
 


### PR DESCRIPTION
If you go on the previous URL, it says:

> This is not the Java library.

With a link to the actual Java library, hosted here: https://github.com/dropwizard/metrics