### PR TITLE
deprecate librato client + add reference to new home

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,10 +67,13 @@ go influxdb.Influxdb(metrics.DefaultRegistry, 10e9, &influxdb.Config{
 })
 ```
 
-Periodically upload every metric to Librato:
+Periodically upload every metric to Librato using the [Librato client](https://github.com/mihasya/go-metrics-librato):
+
+**Note**: the client included with this repository under the `librato` package
+has been deprecated and moved to the repository linked above.
 
 ```go
-import "github.com/rcrowley/go-metrics/librato"
+import "github.com/mihasya/go-metrics-librato"
 
 go librato.Librato(metrics.DefaultRegistry,
     10e9,                  // interval
@@ -102,3 +105,10 @@ StatHat support additionally requires their Go client:
 ```sh
 go get github.com/stathat/go
 ```
+
+Publishing Metrics
+------------------
+
+Clients are available for the following destinations:
+
+* Librato - [https://github.com/mihasya/go-metrics-librato](https://github.com/mihasya/go-metrics-librato)

--- a/librato/librato.go
+++ b/librato/librato.go
@@ -40,6 +40,7 @@ func Librato(r metrics.Registry, d time.Duration, e string, t string, s string, 
 }
 
 func (self *Reporter) Run() {
+	log.Printf("WARNING: This client has been DEPRECATED! It has been moved to https://github.com/mihasya/go-metrics-librato and will be removed from rcrowley/go-metrics on August 5th 2015")
 	ticker := time.Tick(self.Interval)
 	metricsApi := &LibratoClient{self.Email, self.Token}
 	for now := range ticker {


### PR DESCRIPTION
Tried the new client on one of our services, and it worked just as expected - only the import needed to be changed.

This just starts logging a deprecation notice for anyone importing the client from this repo.