### PR TITLE
add a link to the InfluxDB reporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,3 +123,4 @@ Clients are available for the following destinations:
 
 * Librato - [https://github.com/mihasya/go-metrics-librato](https://github.com/mihasya/go-metrics-librato)
 * Graphite - [https://github.com/cyberdelia/go-metrics-graphite](https://github.com/cyberdelia/go-metrics-graphite)
+* InfluxDB - [https://github.com/vrischmann/go-metrics-influxdb](https://github.com/vrischmann/go-metrics-influxdb)


### PR DESCRIPTION
Hi,

I'd like to suggest adding a link to https://github.com/vrischmann/go-metrics-influxdb in the README.

Since right now there's no available reporter for InfluxDB, I had to make one for work.
Only compatible with InfluxDB 0.9 though.

See also #124.