### PR TITLE
Add NewPrefixedChildRegistry()

### DIFF
--- a/registry.go
+++ b/registry.go
@@ -157,6 +157,13 @@ func NewPrefixedRegistry(prefix string) Registry {
 	}
 }
 
+func NewPrefixedChildRegistry(parent Registry, prefix string) Registry {
+	return &PrefixedRegistry{
+		underlying: parent,
+		prefix:     prefix,
+	}
+}
+
 // Call the given function for each registered metric.
 func (r *PrefixedRegistry) Each(fn func(string, interface{})) {
 	r.underlying.Each(fn)

--- a/registry_test.go
+++ b/registry_test.go
@@ -117,6 +117,19 @@ func TestRegistryGetOrRegisterWithLazyInstantiation(t *testing.T) {
 	}
 }
 
+func TestPrefixedChildRegistryGetOrRegister(t *testing.T) {
+	r := NewRegistry()
+	pr := NewPrefixedChildRegistry(r, "prefix.")
+
+	_ = pr.GetOrRegister("foo", NewCounter)
+
+	r.Each(func(name string, m interface{}) {
+		if name != "prefix.foo" {
+			t.Fatal(name)
+		}
+	})
+}
+
 func TestPrefixedRegistryGetOrRegister(t *testing.T) {
 	r := NewPrefixedRegistry("prefix.")
 


### PR DESCRIPTION
`PrefixedRegistry` supports chaining one registry off another, but prior to this commit, the public API did not. `NewPrefixedChildRegistry()` is exactly like `NewPrefixedRegistry()` except it allows an existing `Registry` to be used instead of creating a new registry.