### PR TITLE
add Sample() to Timer, NilTimer, StandardTimer and TimerSnapshot

### DIFF
--- a/timer.go
+++ b/timer.go
@@ -17,6 +17,7 @@ type Timer interface {
 	Rate5() float64
 	Rate15() float64
 	RateMean() float64
+	Sample() Sample
 	Snapshot() Timer
 	StdDev() float64
 	Sum() int64
@@ -106,6 +107,9 @@ func (NilTimer) Rate15() float64 { return 0.0 }
 // RateMean is a no-op.
 func (NilTimer) RateMean() float64 { return 0.0 }
 
+// Sample is a no-op.
+func (NilTimer) Sample() Sample { return NilSample{} }
+
 // Snapshot is a no-op.
 func (NilTimer) Snapshot() Timer { return NilTimer{} }
 
@@ -184,6 +188,11 @@ func (t *StandardTimer) Rate15() float64 {
 // RateMean returns the meter's mean rate of events per second.
 func (t *StandardTimer) RateMean() float64 {
 	return t.meter.RateMean()
+}
+
+// Sample returns the Sample underlying the timer.
+func (t *StandardTimer) Sample() Sample {
+	return t.histogram.Sample()
 }
 
 // Snapshot returns a read-only copy of the timer.
@@ -280,6 +289,9 @@ func (t *TimerSnapshot) Rate15() float64 { return t.meter.Rate15() }
 // RateMean returns the meter's mean rate of events per second at the time the
 // snapshot was taken.
 func (t *TimerSnapshot) RateMean() float64 { return t.meter.RateMean() }
+
+// Sample returns the Sample underlying the histogram.
+func (t *TimerSnapshot) Sample() Sample { return t.histogram.Sample() }
 
 // Snapshot returns the snapshot.
 func (t *TimerSnapshot) Snapshot() Timer { return t }


### PR DESCRIPTION
This exposes Sample() on Timer, just like it is already available on Histogram.  This is necessary to know the number of measurements in a given sample (via `timer.Sample().Size()`), which in turn is useful when gauging the "value" of different percentiles.  For example, publishing the 99th percentile of a Timer is often pointless (or even misleading) if there are only 3 samples that contributed to that distribution.