### PR TITLE
Options for exposing structured metrics in expvars

### DIFF
--- a/exp/exp.go
+++ b/exp/exp.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 )
 
 type config struct {
@@ -27,6 +28,11 @@ type config struct {
 	// Percentiles determines the set of percentile metrics to be
 	// exported for each histogram or timer.
 	Percentiles []float64
+
+	// TimerScale can be used to scale time-based metrics into
+	// different resolutions (i.e time.Milliseconds, etc...). The
+	// default TimerScale is nanoseconds (i.e. no conversion).
+	TimerScale time.Duration
 
 	percentileLabels []string
 }
@@ -85,6 +91,14 @@ func Exp(r metrics.Registry) {
 	// http.HandleFunc("/debug/vars", e.expHandler)
 	// haven't found an elegant way, so just use a different endpoint
 	http.HandleFunc("/debug/metrics", e.expHandler)
+}
+
+func scaleFloat(value float64) float64 {
+	return value / float64(Config.TimerScale)
+}
+
+func scaleInt(value int64) float64 {
+	return float64(value) / float64(Config.TimerScale)
 }
 
 func (exp *exp) getInt(name string) *expvar.Int {
@@ -278,12 +292,12 @@ func (exp *exp) publishTimer(name string, metric metrics.Timer) {
 		t := metric.Snapshot()
 
 		exp.getInt(name + ".count").Set(t.Count())
-		exp.getFloat(name + ".min").Set(float64(t.Min()))
-		exp.getFloat(name + ".max").Set(float64(t.Max()))
-		exp.getFloat(name + ".mean").Set(float64(t.Mean()))
-		exp.getFloat(name + ".std-dev").Set(float64(t.StdDev()))
+		exp.getFloat(name + ".min").Set(scaleInt(t.Min()))
+		exp.getFloat(name + ".max").Set(scaleInt(t.Max()))
+		exp.getFloat(name + ".mean").Set(scaleFloat(t.Mean()))
+		exp.getFloat(name + ".std-dev").Set(scaleFloat(t.StdDev()))
 		for i, p := range t.Percentiles(Config.Percentiles) {
-			exp.getFloat(fmt.Sprintf("%s.%s", name, Config.percentileLabels[i])).Set(float64(p))
+			exp.getFloat(fmt.Sprintf("%s.%s", name, Config.percentileLabels[i])).Set(scaleFloat(p))
 		}
 		exp.getFloat(name + ".one-minute").Set(float64(t.Rate1()))
 		exp.getFloat(name + ".five-minute").Set(float64(t.Rate5()))
@@ -296,11 +310,11 @@ func convertTimer(metric metrics.Timer) *expvar.Map {
 	t := metric.Snapshot()
 	m := newMap()
 	m.Set("count", newInt(t.Count()))
-	m.Set("min", newFloat(float64(t.Min())))
-	m.Set("max", newFloat(float64(t.Max())))
-	m.Set("std-dev", newFloat(t.StdDev()))
+	m.Set("min", newFloat(scaleInt(t.Min())))
+	m.Set("max", newFloat(scaleInt(t.Max())))
+	m.Set("std-dev", newFloat(scaleFloat(t.StdDev())))
 	for i, p := range t.Percentiles(Config.Percentiles) {
-		m.Set(Config.percentileLabels[i], newFloat(p))
+		m.Set(Config.percentileLabels[i], newFloat(scaleFloat(p)))
 	}
 	m.Set("one-minute", newFloat(t.Rate1()))
 	m.Set("five-minute", newFloat(t.Rate5()))

--- a/exp/exp.go
+++ b/exp/exp.go
@@ -5,7 +5,7 @@ package exp
 import (
 	"expvar"
 	"fmt"
-	"github.com/aalpern/go-metrics"
+	"github.com/rcrowley/go-metrics"
 	"net/http"
 	"strconv"
 	"strings"


### PR DESCRIPTION
This adds a few capabilities to the `expvar` support:

* Makes the exported percentiles configurable (I like having the 98th as well as 99th available)
* Adds an option to group all the metrics as a map under a common key (i.e. you can put them all in `"metrics"`, as opposed to just at the root of the expvar JSON blob). A collector grabbing metrics from the `/debug/metrics` endpoint can then just process everything under the metrics key, rather than maintaining a list of non-metrics keys to exclude.
* Adds an option to output metrics as maps, grouping all the rates & percentiles, etc... into a single map per metric, instead of making them all into separate vars (Hi @mihasya! this might look familiar to you :dash: :ship:), which works better than flat for some metrics collectors. 

The defaults are all set so there's no change from existing behavior.

#### Output Examples

Setting a root key:

```json
    "metrics": {
        "http.client.postmark.errors": 0,
        "http.client.postmark.method.GET.50-percentile": 0,
        "http.client.postmark.method.GET.75-percentile": 0,
        "http.client.postmark.method.GET.95-percentile": 0,
        "http.client.postmark.method.GET.99-percentile": 0,
        "http.client.postmark.method.GET.999-percentile": 0,
```

Setting a root key and structured output:

```json
    "metrics": {
        "http.client.postmark.errors": {
            "count": 0
        },
        "http.client.postmark.method.GET": {
            "50-percentile": 0,
            "75-percentile": 0,
            "95-percentile": 0,
            "99-percentile": 0,
            "999-percentile": 0,
            "count": 0,
```
