### PR TITLE
use interface for logger

### DIFF
--- a/log.go
+++ b/log.go
@@ -1,17 +1,20 @@
 package metrics
 
 import (
-	"log"
 	"time"
 )
 
-func Log(r Registry, freq time.Duration, l *log.Logger) {
+type Logger interface {
+	Printf(format string, v ...interface{})
+}
+
+func Log(r Registry, freq time.Duration, l Logger) {
 	LogScaled(r, freq, time.Nanosecond, l)
 }
 
 // Output each metric in the given registry periodically using the given
 // logger. Print timings in `scale` units (eg time.Millisecond) rather than nanos.
-func LogScaled(r Registry, freq time.Duration, scale time.Duration, l *log.Logger) {
+func LogScaled(r Registry, freq time.Duration, scale time.Duration, l Logger) {
 	du := float64(scale)
 	duSuffix := scale.String()[1:]
 


### PR DESCRIPTION
Use interface for logger to allow other implementations

see https://github.com/rcrowley/go-metrics/issues/155