### PR TITLE
Adding FunctionalGauge

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ g := metrics.NewGauge()
 metrics.Register("bar", g)
 g.Update(47)
 
+r := NewRegistry()
+g := metrics.NewRegisteredFunctionalGauge("cache-evictions", r, func() int64 { return cache.getEvictionsCount() })
+
 s := metrics.NewExpDecaySample(1028, 0.015) // or metrics.NewUniformSample(1028)
 h := metrics.NewHistogram(s)
 metrics.Register("baz", h)

--- a/gauge.go
+++ b/gauge.go
@@ -36,6 +36,25 @@ func NewRegisteredGauge(name string, r Registry) Gauge {
 	return c
 }
 
+// NewFunctionalGauge constructs a new FunctionalGauge.
+func NewFunctionalGauge(f func() int64) Gauge {
+	if UseNilMetrics {
+		return NilGauge{}
+	}
+	return &FunctionalGauge{value: f}
+}
+
+
+// NewRegisteredFunctionalGauge constructs and registers a new StandardGauge.
+func NewRegisteredFunctionalGauge(name string, r Registry, f func() int64) Gauge {
+	c := NewFunctionalGauge(f)
+	if nil == r {
+		r = DefaultRegistry
+	}
+	r.Register(name, c)
+	return c
+}
+
 // GaugeSnapshot is a read-only copy of another Gauge.
 type GaugeSnapshot int64
 
@@ -81,4 +100,21 @@ func (g *StandardGauge) Update(v int64) {
 // Value returns the gauge's current value.
 func (g *StandardGauge) Value() int64 {
 	return atomic.LoadInt64(&g.value)
+}
+// FunctionalGauge returns value from given function
+type FunctionalGauge struct {
+	value func() int64
+}
+
+// Value returns the gauge's current value.
+func (g FunctionalGauge) Value() int64 {
+	return g.value()
+}
+
+// Snapshot returns the snapshot.
+func (g FunctionalGauge) Snapshot() Gauge { return GaugeSnapshot(g.Value()) }
+
+// Update panics.
+func (FunctionalGauge) Update(int64) {
+	panic("Update called on a FunctionalGauge")
 }

--- a/gauge_float64_test.go
+++ b/gauge_float64_test.go
@@ -36,3 +36,24 @@ func TestGetOrRegisterGaugeFloat64(t *testing.T) {
 		t.Fatal(g)
 	}
 }
+
+func TestFunctionalGaugeFloat64(t *testing.T) {
+	var counter float64
+	fg := NewFunctionalGaugeFloat64(func() float64 {
+		counter++
+		return counter
+	})
+	fg.Value()
+	fg.Value()
+	if counter != 2 {
+		t.Error("counter != 2")
+	}
+}
+
+func TestGetOrRegisterFunctionalGaugeFloat64(t *testing.T) {
+	r := NewRegistry()
+	NewRegisteredFunctionalGaugeFloat64("foo", r, func() float64 { return 47})
+	if g := GetOrRegisterGaugeFloat64("foo", r); 47 != g.Value() {
+		t.Fatal(g)
+	}
+}

--- a/gauge_test.go
+++ b/gauge_test.go
@@ -35,3 +35,24 @@ func TestGetOrRegisterGauge(t *testing.T) {
 		t.Fatal(g)
 	}
 }
+
+func TestFunctionalGauge(t *testing.T) {
+	var counter int64
+	fg := NewFunctionalGauge(func() int64 {
+		counter++
+		return counter
+	})
+	fg.Value()
+	fg.Value()
+	if counter != 2 {
+		t.Error("counter != 2")
+	}
+}
+
+func TestGetOrRegisterFunctionalGauge(t *testing.T) {
+	r := NewRegistry()
+	NewRegisteredFunctionalGauge("foo", r, func() int64 { return 47})
+	if g := GetOrRegisterGauge("foo", r); 47 != g.Value() {
+		t.Fatal(g)
+	}
+}


### PR DESCRIPTION
Hi

I would like to add new type of Gauge. Main use case is passing function which returns different values over the time instead of explicit call ``gauge.Updata(newValue)``. It's standard use case in origin Java matrics: 

```java
registry.register(name(SessionStore.class, "cache-evictions"), new Gauge<Integer>() {
    @Override
    public Integer getValue() {
        return cache.getEvictionsCount();
    }
});
```

Now I have to implement ``FunctionalGauge`` in all my projects which are using go-metrics, e.g: https://github.com/allegro/marathon-consul/commit/e548d70f7a27be6476550b58e527b67cc9a36e41

Regards
Paweł Szymczyk