### PR TITLE
Add ParseableLog to log metric in local logger file

### DIFF
--- a/log.go
+++ b/log.go
@@ -75,3 +75,72 @@ func LogScaled(r Registry, freq time.Duration, scale time.Duration, l *log.Logge
 		})
 	}
 }
+
+// Output each metric in the given registry periodically using the given logger
+// with parseable format like syslog
+func ParseableLog(r Registry, d time.Duration, l *log.Logger) {
+	for _ = range time.Tick(d) {
+		r.Each(func(name string, i interface{}) {
+			switch metric := i.(type) {
+			case Counter:
+				l.Printf("counter %s: count: %d", name, metric.Count())
+			case Gauge:
+				l.Printf("gauge %s: value: %d", name, metric.Value())
+			case GaugeFloat64:
+				l.Printf("gauge %s: value: %f", name, metric.Value())
+			case Healthcheck:
+				metric.Check()
+				l.Printf("healthcheck %s: error: %v", name, metric.Error())
+			case Histogram:
+				h := metric.Snapshot()
+				ps := h.Percentiles([]float64{0.5, 0.75, 0.95, 0.99, 0.999})
+				l.Printf(
+					"histogram %s: count: %d min: %d max: %d mean: %.2f stddev: %.2f median: %.2f 75%%: %.2f 95%%: %.2f 99%%: %.2f 99.9%%: %.2f",
+					name,
+					h.Count(),
+					h.Min(),
+					h.Max(),
+					h.Mean(),
+					h.StdDev(),
+					ps[0],
+					ps[1],
+					ps[2],
+					ps[3],
+					ps[4],
+				)
+			case Meter:
+				m := metric.Snapshot()
+				l.Printf(
+					"meter %s: count: %d 1-min: %.2f 5-min: %.2f 15-min: %.2f mean: %.2f",
+					name,
+					m.Count(),
+					m.Rate1(),
+					m.Rate5(),
+					m.Rate15(),
+					m.RateMean(),
+				)
+			case Timer:
+				t := metric.Snapshot()
+				ps := t.Percentiles([]float64{0.5, 0.75, 0.95, 0.99, 0.999})
+				l.Printf(
+					"timer %s: count: %d min: %d max: %d mean: %.2f stddev: %.2f median: %.2f 75%%: %.2f 95%%: %.2f 99%%: %.2f 99.9%%: %.2f 1-min: %.2f 5-min: %.2f 15-min: %.2f mean-rate: %.2f",
+					name,
+					t.Count(),
+					t.Min(),
+					t.Max(),
+					t.Mean(),
+					t.StdDev(),
+					ps[0],
+					ps[1],
+					ps[2],
+					ps[3],
+					ps[4],
+					t.Rate1(),
+					t.Rate5(),
+					t.Rate15(),
+					t.RateMean(),
+				)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Hi,

We want to a `ParseableLog` to output each metric in the given registry periodically using the given logger with parseable format just like syslog-format..

because our many system run without syslogd...and using local logger agent to collect monitor data.

please take a look~ thx