### PR TITLE
Adds GoRoutines, and Uptime to debug/metrics.  Adds function to return handler rather than self serve.

### DIFF
--- a/aws/cloudwatch.go
+++ b/aws/cloudwatch.go
@@ -1,0 +1,217 @@
+// Metrics output to StatHat.
+package cloudwatch
+
+import (
+	"log"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/cloudwatch"
+	"github.com/rcrowley/go-metrics"
+)
+
+func EmitMetrics(r *metrics.Registry, d time.Duration, namespace string) {
+
+	for {
+		if errs := emit(*r, namespace); 0 != len(errs) {
+			log.Println(errs)
+		}
+		time.Sleep(d)
+	}
+}
+
+func emit(r metrics.Registry, s string) []string {
+	svc := cloudwatch.New(session.New(), aws.NewConfig().WithRegion("us-east-1"))
+	awsErr := []string{}
+	svc.AddDebugHandlers()
+
+	metricData := []*cloudwatch.MetricDatum{}
+	params := &cloudwatch.PutMetricDataInput{}
+	now := aws.Time(time.Now())
+
+	r.Each(func(name string, i interface{}) {
+		metricData = nil
+		params = nil
+
+		switch metric := i.(type) {
+		case metrics.Counter:
+			metricData = append(metricData, &cloudwatch.MetricDatum{
+				MetricName: aws.String(name),
+				Timestamp:  now,
+				Unit:       aws.String("StandardUnit"),
+				Value:      aws.Float64(float64(metric.Count())),
+			})
+		case metrics.Gauge:
+			metricData = append(metricData, &cloudwatch.MetricDatum{
+				MetricName: aws.String(name),
+				Timestamp:  now,
+				Unit:       aws.String("StandardUnit"),
+				Value:      aws.Float64(float64(metric.Value())),
+			})
+		case metrics.GaugeFloat64:
+			metricData = append(metricData,
+				&cloudwatch.MetricDatum{
+					MetricName: aws.String(name),
+					Timestamp:  now,
+					Unit:       aws.String("StandardUnit"),
+					Value:      aws.Float64(metric.Value()),
+				})
+		case metrics.Histogram:
+			h := metric.Snapshot()
+			// ps := h.Percentiles([]float64{0.5, 0.75, 0.95, 0.99, 0.999})
+			metricData = append(metricData,
+				&cloudwatch.MetricDatum{
+					MetricName: aws.String(name + ".count"),
+					Timestamp:  now,
+					Unit:       aws.String("StandardUnit"),
+					Value:      aws.Float64(float64(h.Count())),
+				},
+				&cloudwatch.MetricDatum{
+					MetricName: aws.String(name + ".min"),
+					Timestamp:  now,
+					Unit:       aws.String("StandardUnit"),
+					Value:      aws.Float64(float64(h.Count())),
+				})
+		case metrics.Meter:
+			m := metric.Snapshot()
+			metricData = append(metricData,
+				&cloudwatch.MetricDatum{
+					MetricName: aws.String(name + ".count"),
+					Timestamp:  now,
+					Unit:       aws.String("Count"),
+					Value:      aws.Float64(float64(m.Count())),
+				},
+				&cloudwatch.MetricDatum{
+					MetricName: aws.String(name + ".one-minute"),
+					Timestamp:  now,
+					Unit:       aws.String("Count/Second"),
+					Value:      aws.Float64(float64(m.Rate1())),
+				},
+				&cloudwatch.MetricDatum{
+					MetricName: aws.String(name + ".five-minute"),
+					Timestamp:  now,
+					Unit:       aws.String("Count/Second"),
+					Value:      aws.Float64(float64(m.Rate5())),
+				},
+				&cloudwatch.MetricDatum{
+					MetricName: aws.String(name + ".fifteen-minute"),
+					Timestamp:  now,
+					Unit:       aws.String("Count/Second"),
+					Value:      aws.Float64(float64(m.Rate15())),
+				},
+				&cloudwatch.MetricDatum{
+					MetricName: aws.String(name + ".mean"),
+					Timestamp:  now,
+					Unit:       aws.String("Count/Second"),
+					Value:      aws.Float64(float64(m.RateMean())),
+				})
+		case metrics.Timer:
+			m := metric.Snapshot()
+			ps := m.Percentiles([]float64{0.5, 0.75, 0.95, 0.99, 0.999})
+			metricData = append(metricData,
+				&cloudwatch.MetricDatum{
+					MetricName: aws.String(name + ".count"),
+					Timestamp:  now,
+					Unit:       aws.String("Count"),
+					Value:      aws.Float64(float64(m.Count())),
+				},
+				&cloudwatch.MetricDatum{
+					MetricName: aws.String(name + ".min"),
+					Timestamp:  now,
+					Unit:       aws.String("Microseconds"),
+					Value:      aws.Float64(float64(m.Min())),
+				},
+				&cloudwatch.MetricDatum{
+					MetricName: aws.String(name + ".max"),
+					Timestamp:  now,
+					Unit:       aws.String("Microseconds"),
+					Value:      aws.Float64(float64(m.Max())),
+				},
+				&cloudwatch.MetricDatum{
+					MetricName: aws.String(name + ".mean"),
+					Timestamp:  now,
+					Unit:       aws.String("Microseconds"),
+					Value:      aws.Float64(float64(m.Mean())),
+				},
+				&cloudwatch.MetricDatum{
+					MetricName: aws.String(name + ".std-dev"),
+					Timestamp:  now,
+					Unit:       aws.String("None"),
+					Value:      aws.Float64(float64(m.StdDev())),
+				},
+				&cloudwatch.MetricDatum{
+					MetricName: aws.String(name + ".one-minute"),
+					Timestamp:  now,
+					Unit:       aws.String("Count/Second"),
+					Value:      aws.Float64(float64(m.Rate1())),
+				},
+				&cloudwatch.MetricDatum{
+					MetricName: aws.String(name + ".five-minute"),
+					Timestamp:  now,
+					Unit:       aws.String("Count/Second"),
+					Value:      aws.Float64(float64(m.Rate5())),
+				},
+				&cloudwatch.MetricDatum{
+					MetricName: aws.String(name + ".fifteen-minute"),
+					Timestamp:  now,
+					Unit:       aws.String("Count/Second"),
+					Value:      aws.Float64(float64(m.Rate15())),
+				},
+				&cloudwatch.MetricDatum{
+					MetricName: aws.String(name + ".mean-rate"),
+					Timestamp:  now,
+					Unit:       aws.String("Count/Second"),
+					Value:      aws.Float64(float64(m.RateMean())),
+				},
+				&cloudwatch.MetricDatum{
+					MetricName: aws.String(name + ".50-percentile"),
+					Timestamp:  now,
+					Unit:       aws.String("Microseconds"),
+					Value:      aws.Float64(float64(ps[0])),
+				},
+				&cloudwatch.MetricDatum{
+					MetricName: aws.String(name + ".75-percentile"),
+					Timestamp:  now,
+					Unit:       aws.String("Microseconds"),
+					Value:      aws.Float64(float64(ps[1])),
+				},
+				&cloudwatch.MetricDatum{
+					MetricName: aws.String(name + ".95-percentile"),
+					Timestamp:  now,
+					Unit:       aws.String("Microseconds"),
+					Value:      aws.Float64(float64(ps[2])),
+				},
+				&cloudwatch.MetricDatum{
+					MetricName: aws.String(name + ".99-percentile"),
+					Timestamp:  now,
+					Unit:       aws.String("Microseconds"),
+					Value:      aws.Float64(float64(ps[3])),
+				},
+				&cloudwatch.MetricDatum{
+					MetricName: aws.String(name + ".999-percentile"),
+					Timestamp:  now,
+					Unit:       aws.String("Microseconds"),
+					Value:      aws.Float64(float64(ps[4])),
+				},
+			)
+		}
+
+		if len(metricData) > 0 {
+			params = &cloudwatch.PutMetricDataInput{
+				MetricData: metricData,
+				Namespace:  aws.String(s),
+			}
+
+			_, err := svc.PutMetricData(params)
+
+			if err != nil {
+				awsErr = append(awsErr, err.Error())
+			}
+		}
+
+	})
+
+	return awsErr
+
+}

--- a/aws/cloudwatch.go
+++ b/aws/cloudwatch.go
@@ -1,6 +1,11 @@
 //Package cloudwatch add a metrics emitter to AWS Cloudwatch
 package cloudwatch
 
+/*
+	Per https://github.com/aws/aws-sdk-go/issues/489 this package expects that
+	you have exported environment variable AWS_REGION
+*/
+
 import (
 	"log"
 	"time"

--- a/aws/cloudwatch.go
+++ b/aws/cloudwatch.go
@@ -1,4 +1,4 @@
-// Metrics emitter for AWS Cloudwatch
+//Package cloudwatch add a metrics emitter to AWS Cloudwatch
 package cloudwatch
 
 import (
@@ -12,9 +12,6 @@ import (
 )
 
 //EmitMetrics emits the metrics in a metrics registry to cloudwatch
-//Param type *metrics.Registry (metrics registry from which to extract metrics)
-//Param type time.Duration (how often to emit metrics)
-//Param type string (Cloudwatch namespace under which metrics will be stored)
 func EmitMetrics(r *metrics.Registry, d time.Duration, namespace string) {
 	svc := cloudwatch.New(session.New())
 	for {

--- a/aws/cloudwatch.go
+++ b/aws/cloudwatch.go
@@ -26,11 +26,9 @@ func emit(svc *cloudwatch.CloudWatch, r metrics.Registry, s string) []string {
 	awsErr := []string{}
 	metricData := []*cloudwatch.MetricDatum{}
 	now := aws.Time(time.Now())
-	params := &cloudwatch.PutMetricDataInput{}
 
 	r.Each(func(name string, i interface{}) {
 		metricData = nil
-		params = nil
 
 		switch metric := i.(type) {
 		case metrics.Counter:
@@ -245,12 +243,10 @@ func emit(svc *cloudwatch.CloudWatch, r metrics.Registry, s string) []string {
 		}
 
 		if len(metricData) > 0 {
-			params = &cloudwatch.PutMetricDataInput{
+			_, err := svc.PutMetricData(&cloudwatch.PutMetricDataInput{
 				MetricData: metricData,
 				Namespace:  aws.String(s),
-			}
-
-			_, err := svc.PutMetricData(params)
+			})
 
 			if err != nil {
 				awsErr = append(awsErr, err.Error())

--- a/aws/cloudwatch.go
+++ b/aws/cloudwatch.go
@@ -1,4 +1,4 @@
-// Metrics output to StatHat.
+// Metrics emitter for AWS Cloudwatch
 package cloudwatch
 
 import (

--- a/exp/exp.go
+++ b/exp/exp.go
@@ -33,13 +33,13 @@ func (exp *exp) expHandler(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprintf(w, "\n}\n")
 }
 
-func Exp(r metrics.Registry) {
+func Exp(r metrics.Registry, rt *router) {
 	e := exp{sync.Mutex{}, r}
 	// this would cause a panic:
 	// panic: http: multiple registrations for /debug/vars
 	// http.HandleFunc("/debug/vars", e.expHandler)
 	// haven't found an elegant way, so just use a different endpoint
-	http.HandleFunc("/debug/metrics", e.expHandler)
+	rt.GET("/debug/metrics", e.expHandler)
 }
 
 func (exp *exp) getInt(name string) *expvar.Int {

--- a/exp/exp.go
+++ b/exp/exp.go
@@ -15,6 +15,7 @@ import (
 
 var startTime = time.Now().UTC()
 
+// returns the number of goroutines for use in metrics output
 func goroutines() interface{} {
 	return runtime.NumGoroutine()
 }
@@ -23,6 +24,12 @@ func goroutines() interface{} {
 func uptime() interface{} {
 	uptime := time.Since(startTime)
 	return int64(uptime)
+}
+
+// publishes the goroutines and uptime to expvar for debug/metrics output
+func AddExpVars() {
+	expvar.Publish("Goroutines", expvar.Func(goroutines))
+	expvar.Publish("Uptime", expvar.Func(uptime))
 }
 
 type exp struct {
@@ -50,12 +57,8 @@ func (exp *exp) expHandler(w http.ResponseWriter, r *http.Request) {
 
 }
 
-func AddExpVars() {
-	expvar.Publish("Goroutines", expvar.Func(goroutines))
-	expvar.Publish("Uptime", expvar.Func(uptime))
-}
-
-//Handler returns the Handler function for use in different routers.
+//Handler returns the expHandler function for use in different routers,
+//rather than handling the function here
 func Handler(r metrics.Registry) func(http.ResponseWriter, *http.Request) {
 	e := exp{sync.Mutex{}, r}
 	return e.expHandler


### PR DESCRIPTION
This publishes # goroutines and uptime to expvar so that they show up in the debug/metrics output.  It also adds a function to return the metrics handler, rather than self serving it, so that the end user can control the routing implementation.