### PR TITLE
Ganglia reporter link added.

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,3 +137,4 @@ Clients are available for the following destinations:
 * Librato - [https://github.com/mihasya/go-metrics-librato](https://github.com/mihasya/go-metrics-librato)
 * Graphite - [https://github.com/cyberdelia/go-metrics-graphite](https://github.com/cyberdelia/go-metrics-graphite)
 * InfluxDB - [https://github.com/vrischmann/go-metrics-influxdb](https://github.com/vrischmann/go-metrics-influxdb)
+* Ganglia - [https://github.com/aerofoil-kite/metlia](https://github.com/aerofoil-kite/metlia)


### PR DESCRIPTION
I and aerofile-kite just tried to use this metrics to publish data to ganglia. and succeeded for counter and histogram. I have just added the links so that, people may get help form this and contribute on it to make it more flexible and efficient.