### PR TITLE
Support dynamic gauge metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,11 @@ g := metrics.NewGauge()
 metrics.Register("bar", g)
 g.Update(47)
 
+f := metrics.NewFuncGauge(func int64 {
+  return int64(runtime.NumGoroutine())
+})
+metrics.Register("goroutines", f)
+
 s := metrics.NewExpDecaySample(1028, 0.015) // or metrics.NewUniformSample(1028)
 h := metrics.NewHistogram(s)
 metrics.Register("baz", h)

--- a/gauge_float64_test.go
+++ b/gauge_float64_test.go
@@ -2,7 +2,7 @@ package metrics
 
 import "testing"
 
-func BenchmarkGuageFloat64(b *testing.B) {
+func BenchmarkGaugeFloat64(b *testing.B) {
 	g := NewGaugeFloat64()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -33,6 +33,58 @@ func TestGetOrRegisterGaugeFloat64(t *testing.T) {
 	NewRegisteredGaugeFloat64("foo", r).Update(float64(47.0))
 	t.Logf("registry: %v", r)
 	if g := GetOrRegisterGaugeFloat64("foo", r); float64(47.0) != g.Value() {
+		t.Fatal(g)
+	}
+}
+
+func TestFuncGaugeFloat64(t *testing.T) {
+	i := 0
+	g := NewFuncGaugeFloat64(func() float64 {
+		i++
+		return float64(i)
+	})
+	for j := 1; j <= 2; j++ {
+		if v := g.Value(); float64(j) != v {
+			t.Errorf("g.Value(): %v != %v\n", j, v)
+		}
+	}
+}
+
+func TestFuncGaugeFloat64Update(t *testing.T) {
+	g := NewFuncGaugeFloat64(func() float64 {
+		return float64(47.0)
+	})
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("Update() did not panic")
+		}
+	}()
+	g.Update(float64(48.0))
+}
+
+func TestFuncGaugeFloat64Snapshot(t *testing.T) {
+	i := 0
+	g := NewFuncGaugeFloat64(func() float64 {
+		i++
+		return float64(i)
+	})
+	snapshot := g.Snapshot()
+	if v := g.Value(); float64(2.0) != v {
+		t.Errorf("g.Value(): 2.0 != %v\n", v)
+	}
+	if v := snapshot.Value(); float64(1.0) != v {
+		t.Errorf("g.Value(): 1.0 != %v\n", v)
+	}
+}
+
+func TestGetOrRegisterFuncGaugeFloat64(t *testing.T) {
+	r := NewRegistry()
+	NewRegisteredFuncGaugeFloat64("foo", r, func() float64 {
+		return float64(47.0)
+	})
+	if g := GetOrRegisterFuncGaugeFloat64("foo", r, func() float64 {
+		return float64(48.0)
+	}); float64(47.0) != g.Value() {
 		t.Fatal(g)
 	}
 }

--- a/gauge_test.go
+++ b/gauge_test.go
@@ -2,7 +2,7 @@ package metrics
 
 import "testing"
 
-func BenchmarkGuage(b *testing.B) {
+func BenchmarkGauge(b *testing.B) {
 	g := NewGauge()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -32,6 +32,58 @@ func TestGetOrRegisterGauge(t *testing.T) {
 	r := NewRegistry()
 	NewRegisteredGauge("foo", r).Update(47)
 	if g := GetOrRegisterGauge("foo", r); 47 != g.Value() {
+		t.Fatal(g)
+	}
+}
+
+func TestFuncGauge(t *testing.T) {
+	i := 0
+	g := NewFuncGauge(func() int64 {
+		i++
+		return int64(i)
+	})
+	for j := 1; j <= 2; j++ {
+		if v := g.Value(); int64(j) != v {
+			t.Errorf("g.Value(): %v != %v\n", j, v)
+		}
+	}
+}
+
+func TestFuncGaugeUpdate(t *testing.T) {
+	g := NewFuncGauge(func() int64 {
+		return int64(47)
+	})
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("Update() did not panic")
+		}
+	}()
+	g.Update(int64(48))
+}
+
+func TestFuncGaugeSnapshot(t *testing.T) {
+	i := 0
+	g := NewFuncGauge(func() int64 {
+		i++
+		return int64(i)
+	})
+	snapshot := g.Snapshot()
+	if v := g.Value(); 2 != v {
+		t.Errorf("g.Value(): 2 != %v\n", v)
+	}
+	if v := snapshot.Value(); 1 != v {
+		t.Errorf("g.Value(): 1 != %v\n", v)
+	}
+}
+
+func TestGetOrRegisterFuncGauge(t *testing.T) {
+	r := NewRegistry()
+	NewRegisteredFuncGauge("foo", r, func() int64 {
+		return int64(47)
+	})
+	if g := GetOrRegisterFuncGauge("foo", r, func() int64 {
+		return int64(48)
+	}); 47 != g.Value() {
 		t.Fatal(g)
 	}
 }


### PR DESCRIPTION
Coming from the Java implementation, I found that the default static gauge makes it difficult to use when the value is either dynamic or required to be synchronized in various location in the code.

It is possible and not too difficult to registered a type that implements the `Gauge` interface but it is cumbersome to do so when it could be builtin especially managing all the `*Register*` calls.

Related issue #35.

Changes:
- on demand Gauge metric through `FuncGauge` and `FuncGaugeFloat64`
- add unit tests
- fix typos in `gauge[_float64]_test.go` benchmarks