### PR TITLE
ChildRegistry should filter by prefix

### DIFF
--- a/exp/exp.go
+++ b/exp/exp.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 	"sync"
 
-	"github.com/splittingfield/go-metrics"
+	"github.com/rcrowley/go-metrics"
 )
 
 type exp struct {

--- a/exp/exp.go
+++ b/exp/exp.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 	"sync"
 
-	"github.com/rcrowley/go-metrics"
+	"github.com/splittingfield/go-metrics"
 )
 
 type exp struct {

--- a/registry.go
+++ b/registry.go
@@ -177,14 +177,14 @@ func (r *PrefixedRegistry) Each(fn func(string, interface{})) {
 		}
 	}
 
-	baseRegistry, prefix := walkRegistries(r, "")
+	baseRegistry, prefix := findPrefix(r, "")
 	baseRegistry.Each(wrappedFn(prefix))
 }
 
-func walkRegistries(registry Registry, prefix string) (Registry, string) {
+func findPrefix(registry Registry, prefix string) (Registry, string) {
 	switch r := registry.(type) {
 	case *PrefixedRegistry:
-		return walkRegistries(r.underlying, r.prefix + prefix)
+		return findPrefix(r.underlying, r.prefix + prefix)
 	case *StandardRegistry:
 		return r, prefix
 	}

--- a/registry.go
+++ b/registry.go
@@ -3,6 +3,7 @@ package metrics
 import (
 	"fmt"
 	"reflect"
+	"strings"
 	"sync"
 )
 
@@ -166,7 +167,14 @@ func NewPrefixedChildRegistry(parent Registry, prefix string) Registry {
 
 // Call the given function for each registered metric.
 func (r *PrefixedRegistry) Each(fn func(string, interface{})) {
-	r.underlying.Each(fn)
+	wrappedFn := func(name string, iface interface{}) {
+		if strings.HasPrefix(name, r.prefix) {
+			fn(name, iface)
+		} else {
+			return
+		}
+	}
+	r.underlying.Each(wrappedFn)
 }
 
 // Get the metric by the given name or nil if none is registered.

--- a/registry_test.go
+++ b/registry_test.go
@@ -156,8 +156,9 @@ func TestPrefixedRegistryGetOrRegister(t *testing.T) {
 
 func TestPrefixedRegistryRegister(t *testing.T) {
 	r := NewPrefixedRegistry("prefix.")
-
 	err := r.Register("foo", NewCounter())
+	c := NewCounter()
+	Register("bar", c)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
@@ -221,5 +222,26 @@ func TestPrefixedChildRegistryGet(t *testing.T) {
 	fooCounter := pr.Get(name)
 	if fooCounter == nil {
 		t.Fatal(name)
+	}
+}
+
+func TestChildPrefixedRegistryRegister(t *testing.T) {
+	r := NewPrefixedChildRegistry(DefaultRegistry, "prefix.")
+	err := r.Register("foo", NewCounter())
+	c := NewCounter()
+	Register("bar", c)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	i := 0
+	r.Each(func(name string, m interface{}) {
+		i++
+		if name != "prefix.foo" {
+			t.Fatal(name)
+		}
+	})
+	if i != 1 {
+		t.Fatal(i)
 	}
 }

--- a/registry_test.go
+++ b/registry_test.go
@@ -2,7 +2,6 @@ package metrics
 
 import (
 	"testing"
-	"github.com/stretchr/testify/assert"
 )
 
 func BenchmarkRegistry(b *testing.B) {
@@ -281,7 +280,10 @@ func TestWalkRegistries(t *testing.T) {
 	c := NewCounter()
 	Register("bars", c)
 
-	_, prefix := walkRegistries(r2, "")
-	assert.Equal(t, "prefix.prefix2.", prefix)
+	_, prefix := findPrefix(r2, "")
+	if "prefix.prefix2." !=  prefix {
+		t.Fatal(prefix)
+	}
+
 
 }


### PR DESCRIPTION
This commit changes the behavior of PrefixedChildRegistry
to only apply the Each function to registered metrics
that have the the appropriate prefix.

This commit contains two changes:
1: An originally failing test showing the behavior
2: A wrapper func around the passed in function
for Each that applies the required filter

The behavior that this addresses was quite unexpected, but happy to discuss if this was the intended behavior.