### PR TITLE
[fixes #188] expose a constructor for SampleSnapshot

### DIFF
--- a/sample.go
+++ b/sample.go
@@ -302,6 +302,13 @@ type SampleSnapshot struct {
 	values []int64
 }
 
+func NewSampleSnapshot(count int64, values []int64) *SampleSnapshot {
+	return &SampleSnapshot{
+		count:  count,
+		values: values,
+	}
+}
+
 // Clear panics.
 func (*SampleSnapshot) Clear() {
 	panic("Clear called on a SampleSnapshot")


### PR DESCRIPTION
This should enable folks to create alternative `Sample` implementations outside the `go-metrics` package namespace.

Addresses #188 