### PR TITLE
gofmt the code

### DIFF
--- a/gauge.go
+++ b/gauge.go
@@ -44,7 +44,6 @@ func NewFunctionalGauge(f func() int64) Gauge {
 	return &FunctionalGauge{value: f}
 }
 
-
 // NewRegisteredFunctionalGauge constructs and registers a new StandardGauge.
 func NewRegisteredFunctionalGauge(name string, r Registry, f func() int64) Gauge {
 	c := NewFunctionalGauge(f)
@@ -101,6 +100,7 @@ func (g *StandardGauge) Update(v int64) {
 func (g *StandardGauge) Value() int64 {
 	return atomic.LoadInt64(&g.value)
 }
+
 // FunctionalGauge returns value from given function
 type FunctionalGauge struct {
 	value func() int64

--- a/gauge_float64_test.go
+++ b/gauge_float64_test.go
@@ -52,7 +52,7 @@ func TestFunctionalGaugeFloat64(t *testing.T) {
 
 func TestGetOrRegisterFunctionalGaugeFloat64(t *testing.T) {
 	r := NewRegistry()
-	NewRegisteredFunctionalGaugeFloat64("foo", r, func() float64 { return 47})
+	NewRegisteredFunctionalGaugeFloat64("foo", r, func() float64 { return 47 })
 	if g := GetOrRegisterGaugeFloat64("foo", r); 47 != g.Value() {
 		t.Fatal(g)
 	}

--- a/registry.go
+++ b/registry.go
@@ -167,9 +167,9 @@ func NewPrefixedChildRegistry(parent Registry, prefix string) Registry {
 
 // Call the given function for each registered metric.
 func (r *PrefixedRegistry) Each(fn func(string, interface{})) {
-	wrappedFn := func (prefix string) func(string, interface{}) {
+	wrappedFn := func(prefix string) func(string, interface{}) {
 		return func(name string, iface interface{}) {
-			if strings.HasPrefix(name,prefix) {
+			if strings.HasPrefix(name, prefix) {
 				fn(name, iface)
 			} else {
 				return
@@ -184,7 +184,7 @@ func (r *PrefixedRegistry) Each(fn func(string, interface{})) {
 func findPrefix(registry Registry, prefix string) (Registry, string) {
 	switch r := registry.(type) {
 	case *PrefixedRegistry:
-		return findPrefix(r.underlying, r.prefix + prefix)
+		return findPrefix(r.underlying, r.prefix+prefix)
 	case *StandardRegistry:
 		return r, prefix
 	}

--- a/registry_test.go
+++ b/registry_test.go
@@ -281,9 +281,8 @@ func TestWalkRegistries(t *testing.T) {
 	Register("bars", c)
 
 	_, prefix := findPrefix(r2, "")
-	if "prefix.prefix2." !=  prefix {
+	if "prefix.prefix2." != prefix {
 		t.Fatal(prefix)
 	}
-
 
 }


### PR DESCRIPTION
Hello.

We have a gofmt check in out git pre-commit hook which prevents a commit if it contains code with formatting issues. We vendor go-metrics, and since it has the formatting issues we have to sidestep the pre-commit hook check. Would you please so kind to merge the formatting changes?

Thank you.