### PR TITLE
EWMA and Sample fix in register() and MarshalJSON()

### DIFF
--- a/json.go
+++ b/json.go
@@ -62,6 +62,24 @@ func (r *StandardRegistry) MarshalJSON() ([]byte, error) {
 			values["5m.rate"] = t.Rate5()
 			values["15m.rate"] = t.Rate15()
 			values["mean.rate"] = t.RateMean()
+		case Sample:
+			s := metric.Snapshot()
+			ps := s.Percentiles([]float64{0.5, 0.75, 0.95, 0.99, 0.999})
+			values["count"] = s.Count()
+			values["max"] = s.Max()
+			values["mean"] = s.Mean()
+			values["min"] = s.Min()
+			values["stddev"] = s.StdDev()
+			values["median"] = ps[0]
+			values["75%"] = ps[1]
+			values["95%"] = ps[2]
+			values["99%"] = ps[3]
+			values["99.9%"] = ps[4]
+			values["sum"] = s.Sum()
+			values["variance"] = s.Variance()
+		case EWMA:
+			e := metric.Snapshot()
+			values["rate"] = e.Rate()
 		}
 		data[name] = values
 	})

--- a/registry.go
+++ b/registry.go
@@ -12,8 +12,16 @@ import (
 // Unregister the existing metric.
 type DuplicateMetric string
 
+// UnknownMetric is an error returned by Registry.Register when an unknown
+// variable was passed to the method.
+type UnknownMetric string
+
 func (err DuplicateMetric) Error() string {
 	return fmt.Sprintf("duplicate metric: %s", string(err))
+}
+
+func (err UnknownMetric) Error() string {
+	return fmt.Sprintf("unknown metric: %s", string(err))
 }
 
 // A Registry holds references to a set of metrics by name and can iterate
@@ -130,8 +138,10 @@ func (r *StandardRegistry) register(name string, i interface{}) error {
 		return DuplicateMetric(name)
 	}
 	switch i.(type) {
-	case Counter, Gauge, GaugeFloat64, Healthcheck, Histogram, Meter, Timer:
+	case Counter, Gauge, GaugeFloat64, Healthcheck, Histogram, Meter, Timer, Sample, EWMA:
 		r.metrics[name] = i
+	default:
+		return UnknownMetric(name)
 	}
 	return nil
 }


### PR DESCRIPTION
This PR aims to fix three things:

1) StandardRegistry.register() checks whether the passed argument
is a valid measuring instrument. However, Sample and EWMA were missing
from the list.

2) StandardRegistry.register() silently ignored incompatible
arguments instead of returning an error, which could make things
harder to debug. A fix introduces a new UnknownMetric error which 
is returned by the method if an invalid argument is passed.

3) Adds missing Sample and EWMA marshalling in 
StandardRegistry.MarshalJSON().