### PR TITLE
Make WriteJSON similar to JSON structure of dropwizard metrics

### DIFF
--- a/json_test.go
+++ b/json_test.go
@@ -3,6 +3,7 @@ package metrics
 import (
 	"bytes"
 	"encoding/json"
+	"strings"
 	"testing"
 )
 
@@ -12,7 +13,7 @@ func TestRegistryMarshallJSON(t *testing.T) {
 	r := NewRegistry()
 	r.Register("counter", NewCounter())
 	enc.Encode(r)
-	if s := b.String(); "{\"counter\":{\"count\":0}}\n" != s {
+	if s := b.String(); strings.Contains(s, "{\"counter\":{\"count\":0}}") == false {
 		t.Fatalf(s)
 	}
 }
@@ -22,7 +23,7 @@ func TestRegistryWriteJSONOnce(t *testing.T) {
 	r.Register("counter", NewCounter())
 	b := &bytes.Buffer{}
 	WriteJSONOnce(r, b)
-	if s := b.String(); s != "{\"counter\":{\"count\":0}}\n" {
+	if s := b.String(); strings.Contains(s, "{\"counter\":{\"count\":0}}") == false {
 		t.Fail()
 	}
 }


### PR DESCRIPTION
Dropwizard HTTP servlet based metrics follows the structure:
```
{
  counters: {
    metric_name: {
       value: 10
  }
}

```

This PR tries to replicate the same structure.