### PR TITLE
Stop timer/meter

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ t.Time(func() {})
 t.Update(47)
 ```
 
-**NOTE:** Be sure to either unregister meters and timers otherwise and they will
+**NOTE:** Be sure to unregister short-lived meters and timers otherwise they will
 leak memory:
 
 ```go

--- a/meter_test.go
+++ b/meter_test.go
@@ -24,9 +24,11 @@ func TestGetOrRegisterMeter(t *testing.T) {
 func TestMeterDecay(t *testing.T) {
 	ma := meterArbiter{
 		ticker: time.NewTicker(time.Millisecond),
+		meters: make(map[int64]*StandardMeter),
 	}
 	m := newStandardMeter()
-	ma.meters = append(ma.meters, m)
+	m.id = ma.newID()
+	ma.meters[m.id] = m
 	go ma.tick()
 	m.Mark(1)
 	rateMean := m.RateMean()

--- a/meter_test.go
+++ b/meter_test.go
@@ -46,6 +46,18 @@ func TestMeterNonzero(t *testing.T) {
 	}
 }
 
+func TestMeterStop(t *testing.T) {
+	l := len(arbiter.meters)
+	m := NewMeter()
+	if len(arbiter.meters) != l+1 {
+		t.Errorf("arbiter.meters: %d != %d\n", l+1, len(arbiter.meters))
+	}
+	m.Stop()
+	if len(arbiter.meters) != l {
+		t.Errorf("arbiter.meters: %d != %d\n", l, len(arbiter.meters))
+	}
+}
+
 func TestMeterSnapshot(t *testing.T) {
 	m := NewMeter()
 	m.Mark(1)

--- a/registry_test.go
+++ b/registry_test.go
@@ -119,6 +119,23 @@ func TestRegistryGetOrRegisterWithLazyInstantiation(t *testing.T) {
 	}
 }
 
+func TestRegistryUnregister(t *testing.T) {
+	l := len(arbiter.meters)
+	r := NewRegistry()
+	r.Register("foo", NewCounter())
+	r.Register("bar", NewMeter())
+	r.Register("baz", NewTimer())
+	if len(arbiter.meters) != l+2 {
+		t.Errorf("arbiter.meters: %d != %d\n", l+2, len(arbiter.meters))
+	}
+	r.Unregister("foo")
+	r.Unregister("bar")
+	r.Unregister("baz")
+	if len(arbiter.meters) != l {
+		t.Errorf("arbiter.meters: %d != %d\n", l+2, len(arbiter.meters))
+	}
+}
+
 func TestPrefixedChildRegistryGetOrRegister(t *testing.T) {
 	r := NewRegistry()
 	pr := NewPrefixedChildRegistry(r, "prefix.")

--- a/timer.go
+++ b/timer.go
@@ -19,6 +19,7 @@ type Timer interface {
 	RateMean() float64
 	Snapshot() Timer
 	StdDev() float64
+	Stop()
 	Sum() int64
 	Time(func())
 	Update(time.Duration)
@@ -112,6 +113,9 @@ func (NilTimer) Snapshot() Timer { return NilTimer{} }
 // StdDev is a no-op.
 func (NilTimer) StdDev() float64 { return 0.0 }
 
+// Stop is a no-op.
+func (NilTimer) Stop() {}
+
 // Sum is a no-op.
 func (NilTimer) Sum() int64 { return 0 }
 
@@ -201,6 +205,11 @@ func (t *StandardTimer) StdDev() float64 {
 	return t.histogram.StdDev()
 }
 
+// Stop stops the meter.
+func (t *StandardTimer) Stop() {
+	t.meter.Stop()
+}
+
 // Sum returns the sum in the sample.
 func (t *StandardTimer) Sum() int64 {
 	return t.histogram.Sum()
@@ -287,6 +296,9 @@ func (t *TimerSnapshot) Snapshot() Timer { return t }
 // StdDev returns the standard deviation of the values at the time the snapshot
 // was taken.
 func (t *TimerSnapshot) StdDev() float64 { return t.histogram.StdDev() }
+
+// Stop is a no-op.
+func (t *TimerSnapshot) Stop() {}
 
 // Sum returns the sum at the time the snapshot was taken.
 func (t *TimerSnapshot) Sum() int64 { return t.histogram.Sum() }

--- a/timer_test.go
+++ b/timer_test.go
@@ -32,6 +32,18 @@ func TestTimerExtremes(t *testing.T) {
 	}
 }
 
+func TestTimerStop(t *testing.T) {
+	l := len(arbiter.meters)
+	tm := NewTimer()
+	if len(arbiter.meters) != l+1 {
+		t.Errorf("arbiter.meters: %d != %d\n", l+1, len(arbiter.meters))
+	}
+	tm.Stop()
+	if len(arbiter.meters) != l {
+		t.Errorf("arbiter.meters: %d != %d\n", l, len(arbiter.meters))
+	}
+}
+
 func TestTimerFunc(t *testing.T) {
 	tm := NewTimer()
 	tm.Time(func() { time.Sleep(50e6) })


### PR DESCRIPTION
based on https://github.com/rcrowley/go-metrics/pull/197
- added `Stop` to timer.
- call `Stop` when metrics are unregistered.
- use lock in `meter Stop()` to avoid data races accessing the `stopped` flag.
- when called `meter Mark()`, return if meter is already stopped (without panicking).