### PR TITLE
Added two new functions to support logging "on demand" via channels. …

### DIFF
--- a/log.go
+++ b/log.go
@@ -22,12 +22,12 @@ func LogOnCue(r Registry, ch chan interface{}, l Logger) {
 // LogScaled outputs each metric in the given registry periodically using the given
 // logger. Print timings in `scale` units (eg time.Millisecond) rather than nanos.
 func LogScaled(r Registry, freq time.Duration, scale time.Duration, l Logger) {
-	ch := make(chan interface{}, 1)
-	go func() {
-		for _ = range time.Tick(freq) {
-			ch <- struct{}{}
+	ch := make(chan interface{})
+	go func(channel chan interface{}) {
+		for range time.Tick(freq) {
+			channel <- struct{}{}
 		}
-	}()
+	}(ch)
 	LogScaledOnCue(r, ch, scale, l)
 }
 
@@ -38,8 +38,7 @@ func LogScaledOnCue(r Registry, ch chan interface{}, scale time.Duration, l Logg
 	du := float64(scale)
 	duSuffix := scale.String()[1:]
 
-	for {
-		<-ch
+	for range ch {
 		r.Each(func(name string, i interface{}) {
 			switch metric := i.(type) {
 			case Counter:
@@ -82,15 +81,15 @@ func LogScaledOnCue(r Registry, ch chan interface{}, scale time.Duration, l Logg
 				ps := t.Percentiles([]float64{0.5, 0.75, 0.95, 0.99, 0.999})
 				l.Printf("timer %s\n", name)
 				l.Printf("  count:       %9d\n", t.Count())
-				l.Printf("  min:         %12.2f%s\n", float64(t.Min()) / du, duSuffix)
-				l.Printf("  max:         %12.2f%s\n", float64(t.Max()) / du, duSuffix)
-				l.Printf("  mean:        %12.2f%s\n", t.Mean() / du, duSuffix)
-				l.Printf("  stddev:      %12.2f%s\n", t.StdDev() / du, duSuffix)
-				l.Printf("  median:      %12.2f%s\n", ps[0] / du, duSuffix)
-				l.Printf("  75%%:         %12.2f%s\n", ps[1] / du, duSuffix)
-				l.Printf("  95%%:         %12.2f%s\n", ps[2] / du, duSuffix)
-				l.Printf("  99%%:         %12.2f%s\n", ps[3] / du, duSuffix)
-				l.Printf("  99.9%%:       %12.2f%s\n", ps[4] / du, duSuffix)
+				l.Printf("  min:         %12.2f%s\n", float64(t.Min())/du, duSuffix)
+				l.Printf("  max:         %12.2f%s\n", float64(t.Max())/du, duSuffix)
+				l.Printf("  mean:        %12.2f%s\n", t.Mean()/du, duSuffix)
+				l.Printf("  stddev:      %12.2f%s\n", t.StdDev()/du, duSuffix)
+				l.Printf("  median:      %12.2f%s\n", ps[0]/du, duSuffix)
+				l.Printf("  75%%:         %12.2f%s\n", ps[1]/du, duSuffix)
+				l.Printf("  95%%:         %12.2f%s\n", ps[2]/du, duSuffix)
+				l.Printf("  99%%:         %12.2f%s\n", ps[3]/du, duSuffix)
+				l.Printf("  99.9%%:       %12.2f%s\n", ps[4]/du, duSuffix)
 				l.Printf("  1-min rate:  %12.2f\n", t.Rate1())
 				l.Printf("  5-min rate:  %12.2f\n", t.Rate5())
 				l.Printf("  15-min rate: %12.2f\n", t.Rate15())

--- a/log.go
+++ b/log.go
@@ -8,18 +8,21 @@ type Logger interface {
 	Printf(format string, v ...interface{})
 }
 
+// Log outputs each metric in the given registry periodically using the given logger.
 func Log(r Registry, freq time.Duration, l Logger) {
 	LogScaled(r, freq, time.Nanosecond, l)
 }
 
+// LogOnCue outputs each metric in the given registry on demand through the channel
+// using the given logger
 func LogOnCue(r Registry, ch chan interface{}, l Logger) {
 	LogScaledOnCue(r, ch, time.Nanosecond, l)
 }
 
-// Output each metric in the given registry periodically using the given
+// LogScaled outputs each metric in the given registry periodically using the given
 // logger. Print timings in `scale` units (eg time.Millisecond) rather than nanos.
 func LogScaled(r Registry, freq time.Duration, scale time.Duration, l Logger) {
-	ch := make(chan struct{}, 1)
+	ch := make(chan interface{}, 1)
 	go func() {
 		for range time.Tick(freq) {
 			ch <- struct{}{}
@@ -28,8 +31,9 @@ func LogScaled(r Registry, freq time.Duration, scale time.Duration, l Logger) {
 	LogScaledOnCue(r, ch, scale, l)
 }
 
-// Output each metric in the given registry on demand through the channel using the given
-// logger. Print timings in `scale` units (eg time.Millisecond) rather than nanos.
+// LogScaledOnCue outputs each metric in the given registry on demand through the channel
+// using the given logger. Print timings in `scale` units (eg time.Millisecond) rather
+// than nanos.
 func LogScaledOnCue(r Registry, ch chan interface{}, scale time.Duration, l Logger) {
 	du := float64(scale)
 	duSuffix := scale.String()[1:]

--- a/log.go
+++ b/log.go
@@ -24,7 +24,7 @@ func LogOnCue(r Registry, ch chan interface{}, l Logger) {
 func LogScaled(r Registry, freq time.Duration, scale time.Duration, l Logger) {
 	ch := make(chan interface{}, 1)
 	go func() {
-		for range time.Tick(freq) {
+		for _ = range time.Tick(freq) {
 			ch <- struct{}{}
 		}
 	}()

--- a/log.go
+++ b/log.go
@@ -12,13 +12,30 @@ func Log(r Registry, freq time.Duration, l Logger) {
 	LogScaled(r, freq, time.Nanosecond, l)
 }
 
+func LogOnCue(r Registry, ch chan interface{}, l Logger) {
+	LogScaledOnCue(r, ch, time.Nanosecond, l)
+}
+
 // Output each metric in the given registry periodically using the given
 // logger. Print timings in `scale` units (eg time.Millisecond) rather than nanos.
 func LogScaled(r Registry, freq time.Duration, scale time.Duration, l Logger) {
+	ch := make(chan struct{}, 1)
+	go func() {
+		for range time.Tick(freq) {
+			ch <- struct{}{}
+		}
+	}()
+	LogScaledOnCue(r, ch, scale, l)
+}
+
+// Output each metric in the given registry on demand through the channel using the given
+// logger. Print timings in `scale` units (eg time.Millisecond) rather than nanos.
+func LogScaledOnCue(r Registry, ch chan interface{}, scale time.Duration, l Logger) {
 	du := float64(scale)
 	duSuffix := scale.String()[1:]
 
-	for _ = range time.Tick(freq) {
+	for {
+		<-ch
 		r.Each(func(name string, i interface{}) {
 			switch metric := i.(type) {
 			case Counter:
@@ -61,15 +78,15 @@ func LogScaled(r Registry, freq time.Duration, scale time.Duration, l Logger) {
 				ps := t.Percentiles([]float64{0.5, 0.75, 0.95, 0.99, 0.999})
 				l.Printf("timer %s\n", name)
 				l.Printf("  count:       %9d\n", t.Count())
-				l.Printf("  min:         %12.2f%s\n", float64(t.Min())/du, duSuffix)
-				l.Printf("  max:         %12.2f%s\n", float64(t.Max())/du, duSuffix)
-				l.Printf("  mean:        %12.2f%s\n", t.Mean()/du, duSuffix)
-				l.Printf("  stddev:      %12.2f%s\n", t.StdDev()/du, duSuffix)
-				l.Printf("  median:      %12.2f%s\n", ps[0]/du, duSuffix)
-				l.Printf("  75%%:         %12.2f%s\n", ps[1]/du, duSuffix)
-				l.Printf("  95%%:         %12.2f%s\n", ps[2]/du, duSuffix)
-				l.Printf("  99%%:         %12.2f%s\n", ps[3]/du, duSuffix)
-				l.Printf("  99.9%%:       %12.2f%s\n", ps[4]/du, duSuffix)
+				l.Printf("  min:         %12.2f%s\n", float64(t.Min()) / du, duSuffix)
+				l.Printf("  max:         %12.2f%s\n", float64(t.Max()) / du, duSuffix)
+				l.Printf("  mean:        %12.2f%s\n", t.Mean() / du, duSuffix)
+				l.Printf("  stddev:      %12.2f%s\n", t.StdDev() / du, duSuffix)
+				l.Printf("  median:      %12.2f%s\n", ps[0] / du, duSuffix)
+				l.Printf("  75%%:         %12.2f%s\n", ps[1] / du, duSuffix)
+				l.Printf("  95%%:         %12.2f%s\n", ps[2] / du, duSuffix)
+				l.Printf("  99%%:         %12.2f%s\n", ps[3] / du, duSuffix)
+				l.Printf("  99.9%%:       %12.2f%s\n", ps[4] / du, duSuffix)
 				l.Printf("  1-min rate:  %12.2f\n", t.Rate1())
 				l.Printf("  5-min rate:  %12.2f\n", t.Rate5())
 				l.Printf("  15-min rate: %12.2f\n", t.Rate15())

--- a/log.go
+++ b/log.go
@@ -24,7 +24,7 @@ func LogOnCue(r Registry, ch chan interface{}, l Logger) {
 func LogScaled(r Registry, freq time.Duration, scale time.Duration, l Logger) {
 	ch := make(chan interface{})
 	go func(channel chan interface{}) {
-		for range time.Tick(freq) {
+		for _ := range time.Tick(freq) {
 			channel <- struct{}{}
 		}
 	}(ch)
@@ -38,7 +38,7 @@ func LogScaledOnCue(r Registry, ch chan interface{}, scale time.Duration, l Logg
 	du := float64(scale)
 	duSuffix := scale.String()[1:]
 
-	for range ch {
+	for _ := range ch {
 		r.Each(func(name string, i interface{}) {
 			switch metric := i.(type) {
 			case Counter:

--- a/log.go
+++ b/log.go
@@ -24,7 +24,7 @@ func LogOnCue(r Registry, ch chan interface{}, l Logger) {
 func LogScaled(r Registry, freq time.Duration, scale time.Duration, l Logger) {
 	ch := make(chan interface{})
 	go func(channel chan interface{}) {
-		for _ := range time.Tick(freq) {
+		for _ = range time.Tick(freq) {
 			channel <- struct{}{}
 		}
 	}(ch)
@@ -38,7 +38,7 @@ func LogScaledOnCue(r Registry, ch chan interface{}, scale time.Duration, l Logg
 	du := float64(scale)
 	duSuffix := scale.String()[1:]
 
-	for _ := range ch {
+	for _ = range ch {
 		r.Each(func(name string, i interface{}) {
 			switch metric := i.(type) {
 			case Counter:


### PR DESCRIPTION
… LogOnCue and LogScaledOnCue accept a generic message channel (instead of a time.Duration) which triggers logging to the supplied logger.