### PR TITLE
Add dump method for standard registry

### DIFF
--- a/json.go
+++ b/json.go
@@ -9,7 +9,7 @@ import (
 // MarshalJSON returns a byte slice containing a JSON representation of all
 // the metrics in the Registry.
 func (r *StandardRegistry) MarshalJSON() ([]byte, error) {
-	return json.Marshal(r.Dump())
+	return json.Marshal(r.GetAll())
 }
 
 // WriteJSON writes metrics from the given registry  periodically to the
@@ -27,5 +27,5 @@ func WriteJSONOnce(r Registry, w io.Writer) {
 }
 
 func (p *PrefixedRegistry) MarshalJSON() ([]byte, error) {
-	return json.Marshal(p.Dump())
+	return json.Marshal(p.GetAll())
 }

--- a/json.go
+++ b/json.go
@@ -9,6 +9,11 @@ import (
 // MarshalJSON returns a byte slice containing a JSON representation of all
 // the metrics in the Registry.
 func (r *StandardRegistry) MarshalJSON() ([]byte, error) {
+	return json.Marshal(r.Dump())
+}
+
+// Dump all the metrics in the Registry
+func (r *StandardRegistry) Dump() map[string]map[string]interface{} {
 	data := make(map[string]map[string]interface{})
 	r.Each(func(name string, i interface{}) {
 		values := make(map[string]interface{})
@@ -65,7 +70,7 @@ func (r *StandardRegistry) MarshalJSON() ([]byte, error) {
 		}
 		data[name] = values
 	})
-	return json.Marshal(data)
+	return data
 }
 
 // WriteJSON writes metrics from the given registry  periodically to the

--- a/json.go
+++ b/json.go
@@ -12,67 +12,6 @@ func (r *StandardRegistry) MarshalJSON() ([]byte, error) {
 	return json.Marshal(r.Dump())
 }
 
-// Dump all the metrics in the Registry
-func (r *StandardRegistry) Dump() map[string]map[string]interface{} {
-	data := make(map[string]map[string]interface{})
-	r.Each(func(name string, i interface{}) {
-		values := make(map[string]interface{})
-		switch metric := i.(type) {
-		case Counter:
-			values["count"] = metric.Count()
-		case Gauge:
-			values["value"] = metric.Value()
-		case GaugeFloat64:
-			values["value"] = metric.Value()
-		case Healthcheck:
-			values["error"] = nil
-			metric.Check()
-			if err := metric.Error(); nil != err {
-				values["error"] = metric.Error().Error()
-			}
-		case Histogram:
-			h := metric.Snapshot()
-			ps := h.Percentiles([]float64{0.5, 0.75, 0.95, 0.99, 0.999})
-			values["count"] = h.Count()
-			values["min"] = h.Min()
-			values["max"] = h.Max()
-			values["mean"] = h.Mean()
-			values["stddev"] = h.StdDev()
-			values["median"] = ps[0]
-			values["75%"] = ps[1]
-			values["95%"] = ps[2]
-			values["99%"] = ps[3]
-			values["99.9%"] = ps[4]
-		case Meter:
-			m := metric.Snapshot()
-			values["count"] = m.Count()
-			values["1m.rate"] = m.Rate1()
-			values["5m.rate"] = m.Rate5()
-			values["15m.rate"] = m.Rate15()
-			values["mean.rate"] = m.RateMean()
-		case Timer:
-			t := metric.Snapshot()
-			ps := t.Percentiles([]float64{0.5, 0.75, 0.95, 0.99, 0.999})
-			values["count"] = t.Count()
-			values["min"] = t.Min()
-			values["max"] = t.Max()
-			values["mean"] = t.Mean()
-			values["stddev"] = t.StdDev()
-			values["median"] = ps[0]
-			values["75%"] = ps[1]
-			values["95%"] = ps[2]
-			values["99%"] = ps[3]
-			values["99.9%"] = ps[4]
-			values["1m.rate"] = t.Rate1()
-			values["5m.rate"] = t.Rate5()
-			values["15m.rate"] = t.Rate15()
-			values["mean.rate"] = t.RateMean()
-		}
-		data[name] = values
-	})
-	return data
-}
-
 // WriteJSON writes metrics from the given registry  periodically to the
 // specified io.Writer as JSON.
 func WriteJSON(r Registry, d time.Duration, w io.Writer) {
@@ -88,5 +27,5 @@ func WriteJSONOnce(r Registry, w io.Writer) {
 }
 
 func (p *PrefixedRegistry) MarshalJSON() ([]byte, error) {
-	return json.Marshal(p.underlying)
+	return json.Marshal(p.Dump())
 }

--- a/registry.go
+++ b/registry.go
@@ -29,6 +29,9 @@ type Registry interface {
 	// Get the metric by the given name or nil if none is registered.
 	Get(string) interface{}
 
+	// GetAll metrics in the Registry.
+	GetAll() map[string]map[string]interface{}
+
 	// Gets an existing metric or registers the given one.
 	// The interface can be the metric to register if not found in registry,
 	// or a function returning the metric for lazy instantiation.
@@ -39,9 +42,6 @@ type Registry interface {
 
 	// Run all registered healthchecks.
 	RunHealthchecks()
-
-	// Dump all metrics.
-	Dump() map[string]map[string]interface{}
 
 	// Unregister the metric with the given name.
 	Unregister(string)
@@ -112,8 +112,8 @@ func (r *StandardRegistry) RunHealthchecks() {
 	}
 }
 
-// Dump all the metrics in the Registry
-func (r *StandardRegistry) Dump() map[string]map[string]interface{} {
+// GetAll metrics in the Registry
+func (r *StandardRegistry) GetAll() map[string]map[string]interface{} {
 	data := make(map[string]map[string]interface{})
 	r.Each(func(name string, i interface{}) {
 		values := make(map[string]interface{})
@@ -280,9 +280,9 @@ func (r *PrefixedRegistry) RunHealthchecks() {
 	r.underlying.RunHealthchecks()
 }
 
-// Dump all the metrics in the Registry
-func (r *PrefixedRegistry) Dump() map[string]map[string]interface{} {
-	return r.underlying.Dump()
+// GetAll metrics in the Registry
+func (r *PrefixedRegistry) GetAll() map[string]map[string]interface{} {
+	return r.underlying.GetAll()
 }
 
 // Unregister the metric with the given name. The name will be prefixed.

--- a/registry.go
+++ b/registry.go
@@ -40,6 +40,9 @@ type Registry interface {
 	// Run all registered healthchecks.
 	RunHealthchecks()
 
+	// Dump all metrics.
+	Dump() map[string]map[string]interface{}
+
 	// Unregister the metric with the given name.
 	Unregister(string)
 
@@ -107,6 +110,67 @@ func (r *StandardRegistry) RunHealthchecks() {
 			h.Check()
 		}
 	}
+}
+
+// Dump all the metrics in the Registry
+func (r *StandardRegistry) Dump() map[string]map[string]interface{} {
+	data := make(map[string]map[string]interface{})
+	r.Each(func(name string, i interface{}) {
+		values := make(map[string]interface{})
+		switch metric := i.(type) {
+		case Counter:
+			values["count"] = metric.Count()
+		case Gauge:
+			values["value"] = metric.Value()
+		case GaugeFloat64:
+			values["value"] = metric.Value()
+		case Healthcheck:
+			values["error"] = nil
+			metric.Check()
+			if err := metric.Error(); nil != err {
+				values["error"] = metric.Error().Error()
+			}
+		case Histogram:
+			h := metric.Snapshot()
+			ps := h.Percentiles([]float64{0.5, 0.75, 0.95, 0.99, 0.999})
+			values["count"] = h.Count()
+			values["min"] = h.Min()
+			values["max"] = h.Max()
+			values["mean"] = h.Mean()
+			values["stddev"] = h.StdDev()
+			values["median"] = ps[0]
+			values["75%"] = ps[1]
+			values["95%"] = ps[2]
+			values["99%"] = ps[3]
+			values["99.9%"] = ps[4]
+		case Meter:
+			m := metric.Snapshot()
+			values["count"] = m.Count()
+			values["1m.rate"] = m.Rate1()
+			values["5m.rate"] = m.Rate5()
+			values["15m.rate"] = m.Rate15()
+			values["mean.rate"] = m.RateMean()
+		case Timer:
+			t := metric.Snapshot()
+			ps := t.Percentiles([]float64{0.5, 0.75, 0.95, 0.99, 0.999})
+			values["count"] = t.Count()
+			values["min"] = t.Min()
+			values["max"] = t.Max()
+			values["mean"] = t.Mean()
+			values["stddev"] = t.StdDev()
+			values["median"] = ps[0]
+			values["75%"] = ps[1]
+			values["95%"] = ps[2]
+			values["99%"] = ps[3]
+			values["99.9%"] = ps[4]
+			values["1m.rate"] = t.Rate1()
+			values["5m.rate"] = t.Rate5()
+			values["15m.rate"] = t.Rate15()
+			values["mean.rate"] = t.RateMean()
+		}
+		data[name] = values
+	})
+	return data
 }
 
 // Unregister the metric with the given name.
@@ -214,6 +278,11 @@ func (r *PrefixedRegistry) Register(name string, metric interface{}) error {
 // Run all registered healthchecks.
 func (r *PrefixedRegistry) RunHealthchecks() {
 	r.underlying.RunHealthchecks()
+}
+
+// Dump all the metrics in the Registry
+func (r *PrefixedRegistry) Dump() map[string]map[string]interface{} {
+	return r.underlying.Dump()
 }
 
 // Unregister the metric with the given name. The name will be prefixed.


### PR DESCRIPTION
This method will allow the library user to export the metrics as yaml or any other format.