### PR TITLE
NilTimer executes given function

### DIFF
--- a/timer.go
+++ b/timer.go
@@ -125,8 +125,8 @@ func (NilTimer) Stop() {}
 // Sum is a no-op.
 func (NilTimer) Sum() int64 { return 0 }
 
-// Time is a no-op.
-func (NilTimer) Time(func()) {}
+// Time guarantees execution of the given function, but is otherwise a no-op.
+func (NilTimer) Time(f func()) { f() }
 
 // Update is a no-op.
 func (NilTimer) Update(time.Duration) {}

--- a/timer_test.go
+++ b/timer_test.go
@@ -23,6 +23,15 @@ func TestGetOrRegisterTimer(t *testing.T) {
 	}
 }
 
+func TestNilTimerFunc(t *testing.T) {
+	tm := NilTimer{}
+	b := false
+	tm.Time(func() { b = true })
+	if !b {
+		t.Errorf("tm.Time(func()) did not execute argument")
+	}
+}
+
 func TestTimerExtremes(t *testing.T) {
 	tm := NewTimer()
 	tm.Update(math.MaxInt64)


### PR DESCRIPTION
NilTimer preserves the contract of Time() by executing the function
passed to it

Fixes: #228 