### PR TITLE
Added Wavefront Client to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,3 +165,4 @@ Clients are available for the following destinations:
 * DataDog - https://github.com/syntaqx/go-metrics-datadog
 * SignalFX - https://github.com/pascallouisperez/go-metrics-signalfx
 * Honeycomb - https://github.com/getspine/go-metrics-honeycomb
+* Wavefront - https://github.com/wavefrontHQ/go-metrics-wavefront


### PR DESCRIPTION
Would kindly like to add the Wavefront client to the README.

Wavefront (a SaaS based monitoring solution owned by VMware) has a `go-metrics-wavefront` client that is used widely.