### PR TITLE
exp: export healthcheck status

### DIFF
--- a/cmd/metrics-example/metrics-example.go
+++ b/cmd/metrics-example/metrics-example.go
@@ -2,8 +2,12 @@ package main
 
 import (
 	"errors"
+	// "fmt"
 	"github.com/rcrowley/go-metrics"
+	// "github.com/rcrowley/go-metrics/exp"
 	// "github.com/rcrowley/go-metrics/stathat"
+	// "net"
+	// "net/http"
 	"log"
 	"math/rand"
 	"os"
@@ -69,7 +73,7 @@ func main() {
 	}
 
 	hc := metrics.NewHealthcheck(func(h metrics.Healthcheck) {
-		if 0 < rand.Intn(2) {
+		if 0 == rand.Intn(2) {
 			h.Healthy()
 		} else {
 			h.Unhealthy(errors.New("baz"))
@@ -135,6 +139,22 @@ func main() {
 	go metrics.CaptureRuntimeMemStats(r, 5e9)
 
 	metrics.Log(r, 60e9, log.New(os.Stderr, "metrics: ", log.Lmicroseconds))
+
+	/*
+		mux := http.NewServeMux()
+		mux.Handle("/", exp.ExpHandler(r))
+		server := &http.Server{Handler: mux}
+		addr, err := net.ResolveTCPAddr("tcp", "127.0.0.1:0")
+		if err != nil {
+			panic(err)
+		}
+		listener, err := net.ListenTCP("tcp", addr)
+		if err != nil {
+			panic(err)
+		}
+		fmt.Printf("Listening on %s\n", listener.Addr())
+		server.Serve(listener)
+	*/
 
 	/*
 		w, err := syslog.Dial("unixgram", "/dev/log", syslog.LOG_INFO, "metrics")


### PR DESCRIPTION
This will trigger the check immediately, then export its status as
".status" with value of 1 if the healthcheck is OK and 0 otherwise. If
the status is 0, the error is stored in ".error", otherwise an empty
string is used.

Fix #213