### PR TITLE
healthcheck: implement GetOrRegisterHealthcheck and NewRegisteredHealthcheck

### DIFF
--- a/healthcheck_test.go
+++ b/healthcheck_test.go
@@ -1,0 +1,17 @@
+package metrics
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestGetOrRegisterHealthcheck(t *testing.T) {
+	r := NewRegistry()
+	check := func(h Healthcheck) {
+		h.Unhealthy(errors.New("foo"))
+	}
+	NewRegisteredHealthcheck("foo", r, check).Check()
+	if h := GetOrRegisterHealthcheck("foo", r, check); h.Error().Error() != "foo" {
+		t.Fatal(h)
+	}
+}


### PR DESCRIPTION
Other metric implementations have those methods. Let's add them for
healthchecks too.