### PR TITLE
meter: once all meters are stopped, reset arbiter

### DIFF
--- a/meter_test.go
+++ b/meter_test.go
@@ -34,7 +34,7 @@ func TestMeterConcurrency(t *testing.T) {
 	}
 	m := newStandardMeter()
 	ma.meters[m] = struct{}{}
-	go ma.tick()
+	go ma.tick(ma.ticker, nil)
 	wg := &sync.WaitGroup{}
 	reps := 100
 	for i := 0; i < reps; i++ {
@@ -67,7 +67,7 @@ func TestMeterDecay(t *testing.T) {
 	}
 	m := newStandardMeter()
 	ma.meters[m] = struct{}{}
-	go ma.tick()
+	go ma.tick(ma.ticker, nil)
 	m.Mark(1)
 	rateMean := m.RateMean()
 	time.Sleep(100 * time.Millisecond)


### PR DESCRIPTION
There's a background goroutine that always runs once a single (non-nil) meter has been added to the system. Even if that meter stops, the background goroutine continues to run. This confuses unit and component tests that check for goroutine leakage. Until this PR, there was no way to terminate the background (arbiter) goroutine created by this package.

With the introduction of this change, once all known meters have been stopped the arbiter is "reset" and the background goroutine terminated.

An example of a popular goroutine leak checker: https://github.com/fortytw2/leaktest