### PR TITLE
Add appoptics client link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Publishing Metrics
 
 Clients are available for the following destinations:
 
+* AppOptics - https://github.com/ysamlan/go-metrics-appoptics
 * Librato - https://github.com/mihasya/go-metrics-librato
 * Graphite - https://github.com/cyberdelia/go-metrics-graphite
 * InfluxDB - https://github.com/vrischmann/go-metrics-influxdb


### PR DESCRIPTION
I published a client for the newer AppOptics tagged metrics API (based off @mihasya 's original Librato source-based client - which is great!). Just adding a link to it.