### PR TITLE
Add use of results computed in BenchmarkCompute1000,1000000

### DIFF
--- a/sample_test.go
+++ b/sample_test.go
@@ -7,6 +7,8 @@ import (
 	"time"
 )
 
+var ExportedF64 float64 // Assign to this to prevent dead code elimination
+
 // Benchmark{Compute,Copy}{1000,1000000} demonstrate that, even for relatively
 // expensive computations like Variance, the cost of copying the Sample, as
 // approximated by a make and copy, is much greater than the cost of the
@@ -17,9 +19,11 @@ func BenchmarkCompute1000(b *testing.B) {
 		s[i] = int64(i)
 	}
 	b.ResetTimer()
+	var a float64
 	for i := 0; i < b.N; i++ {
-		SampleVariance(s)
+		a += SampleVariance(s)
 	}
+	ExportedF64 = a
 }
 func BenchmarkCompute1000000(b *testing.B) {
 	s := make([]int64, 1000000)
@@ -27,9 +31,11 @@ func BenchmarkCompute1000000(b *testing.B) {
 		s[i] = int64(i)
 	}
 	b.ResetTimer()
+	var a float64
 	for i := 0; i < b.N; i++ {
-		SampleVariance(s)
+		a += SampleVariance(s)
 	}
+	ExportedF64 = a
 }
 func BenchmarkCopy1000(b *testing.B) {
 	s := make([]int64, 1000)


### PR DESCRIPTION
Gollvm inlines aggressively and discovers more dead code,
resulting in very bogus benchmark results (zero nanoseconds).
This prevents this (for this benchmark; others may need the
same treatment).