### PR TITLE
Fixed a race condition between Unregister and registered

### DIFF
--- a/registry.go
+++ b/registry.go
@@ -219,9 +219,9 @@ type metricKV struct {
 }
 
 func (r *StandardRegistry) registered() []metricKV {
-	metrics := make([]metricKV, 0, len(r.metrics))
 	r.mutex.RLock()
 	defer r.mutex.RUnlock()
+	metrics := make([]metricKV, 0, len(r.metrics))
 	for name, i := range r.metrics {
 		metrics = append(metrics, metricKV{
 			name:  name,


### PR DESCRIPTION
Found a race condition between Unregister() and registered()

==================
WARNING: DATA RACE
Read at 0x00c000099b90 by goroutine 70:
github.com/rcrowley/go-metrics.(*StandardRegistry).registered()
/Users/lechner/Documents/go/src/github.com/rcrowley/go-metrics/registry.go:222 +0x91
github.com/rcrowley/go-metrics.(*StandardRegistry).Each()
/Users/lechner/Documents/go/src/github.com/rcrowley/go-metrics/registry.go:67 +0x3c
github.com/rcrowley/go-metrics/exp.(*exp).syncToExpvar()
/Users/lechner/Documents/go/src/github.com/rcrowley/go-metrics/exp/exp.go:138 +0xb9
github.com/rcrowley/go-metrics/exp.(*exp).expHandler()
/Users/lechner/Documents/go/src/github.com/rcrowley/go-metrics/exp/exp.go:21 +0x50
github.com/rcrowley/go-metrics/exp.(*exp).expHandler-fm()
/Users/lechner/Documents/go/src/github.com/rcrowley/go-metrics/exp/exp.go:19 +0x5f
net/http.HandlerFunc.ServeHTTP()
/usr/local/go/src/net/http/server.go:1995 +0x51

Previous write at 0x00c000099b90 by goroutine 61:
runtime.mapdelete_faststr()
/usr/local/go/src/runtime/map_faststr.go:297 +0x0
github.com/rcrowley/go-metrics.(*StandardRegistry).Unregister()
/Users/lechner/Documents/go/src/github.com/rcrowley/go-metrics/registry.go:192 +0xce
github.com/rcrowley/go-metrics.(*PrefixedRegistry).Unregister()
/Users/lechner/Documents/go/src/github.com/rcrowley/go-metrics/registry.go:325 +0xc6