### PR TITLE
Reduce memory leak from issue 244

### DIFF
--- a/ewma.go
+++ b/ewma.go
@@ -20,7 +20,9 @@ func NewEWMA(alpha float64) EWMA {
 	if UseNilMetrics {
 		return NilEWMA{}
 	}
-	return &StandardEWMA{alpha: alpha}
+	ret := new(StandardEWMA)
+	ret.alpha = alpha
+	return ret
 }
 
 // NewEWMA1 constructs a new EWMA for a one-minute moving average.

--- a/meter.go
+++ b/meter.go
@@ -133,13 +133,13 @@ type StandardMeter struct {
 }
 
 func newStandardMeter() *StandardMeter {
-	return &StandardMeter{
-		snapshot:  &MeterSnapshot{},
-		a1:        NewEWMA1(),
-		a5:        NewEWMA5(),
-		a15:       NewEWMA15(),
-		startTime: time.Now(),
-	}
+	ret := new(StandardMeter)
+	ret.snapshot = new(MeterSnapshot)
+	ret.a1 = NewEWMA1()
+	ret.a5 = NewEWMA5()
+	ret.a15 = NewEWMA15()
+	ret.startTime = time.Now()
+	return ret
 }
 
 // Stop stops the meter, Mark() will be a no-op if you use it after being stopped.


### PR DESCRIPTION
fixes #244 

It isn't the most pretty to split out, it could possibly even just be assigned with the declaration notation, but this has been running stable for an hour with none of the memory impacts seen by just returning the pointer without assigning it first.