### PR TITLE
fix race

### DIFF
--- a/registry.go
+++ b/registry.go
@@ -219,9 +219,9 @@ type metricKV struct {
 }
 
 func (r *StandardRegistry) registered() []metricKV {
-	metrics := make([]metricKV, 0, len(r.metrics))
 	r.mutex.RLock()
 	defer r.mutex.RUnlock()
+	metrics := make([]metricKV, 0, len(r.metrics))
 	for name, i := range r.metrics {
 		metrics = append(metrics, metricKV{
 			name:  name,

--- a/registry_test.go
+++ b/registry_test.go
@@ -377,3 +377,17 @@ func TestConcurrentRegistryAccess(t *testing.T) {
 		t.Fatal(i)
 	}
 }
+
+// exercise race detector
+func TestRegisterAndRegisteredConcurrency(t *testing.T)  {
+	r := NewRegistry()
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+	go func(r Registry, wg *sync.WaitGroup) {
+		defer wg.Done()
+		r.Each(func(name string, iface interface{}) {
+		})
+	}(r, wg)
+	r.Register("foo", NewCounter())
+	wg.Wait()
+}


### PR DESCRIPTION
we got a race like this :

WARNING: DATA RACE
Read at 0x00c000249260 by goroutine 16:
  gmessage-server/vendor/github.com/rcrowley/go-metrics.(*StandardRegistry).registered()
      /home/work/buildspace/2d9632c8a4/.gopath/src/gmessage-server/vendor/github.com/rcrowley/go-metrics/registry.go:222 +0x91
  gmessage-server/vendor/github.com/rcrowley/go-metrics.(*StandardRegistry).Each()
      /home/work/buildspace/2d9632c8a4/.gopath/src/gmessage-server/vendor/github.com/rcrowley/go-metrics/registry.go:67 +0x3c
  ...

Previous write at 0x00c000249260 by goroutine 131:
  runtime.mapassign_faststr()
      /usr/local/go/src/runtime/map_faststr.go:190 +0x0
  gmessage-server/vendor/github.com/rcrowley/go-metrics.(*StandardRegistry).register()
      /home/work/buildspace/2d9632c8a4/.gopath/src/gmessage-server/vendor/github.com/rcrowley/go-metrics/registry.go:211 +0x113
  gmessage-server/vendor/github.com/rcrowley/go-metrics.(*StandardRegistry).GetOrRegister()
      /home/work/buildspace/2d9632c8a4/.gopath/src/gmessage-server/vendor/github.com/rcrowley/go-metrics/registry.go:103 +0x255
  gmessage-server/vendor/github.com/rcrowley/go-metrics.GetOrRegisterTimer()
      /home/work/buildspace/2d9632c8a4/.gopath/src/gmessage-server/vendor/github.com/rcrowley/go-metrics/timer.go:38 +0x77
 ...