### PR TITLE
Add new influxdb metrics reporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Clients are available for the following destinations:
 * AppOptics - https://github.com/ysamlan/go-metrics-appoptics
 * Librato - https://github.com/mihasya/go-metrics-librato
 * Graphite - https://github.com/cyberdelia/go-metrics-graphite
-* InfluxDB - https://github.com/vrischmann/go-metrics-influxdb
+* InfluxDB - https://github.com/vrischmann/go-metrics-influxdb / https://github.com/tehsphinx/metrics
 * Ganglia - https://github.com/appscode/metlia
 * Prometheus - https://github.com/deathowl/go-metrics-prometheus
 * DataDog - https://github.com/syntaqx/go-metrics-datadog


### PR DESCRIPTION
I have written a new metrics reporter for influxDB. It uses the same data-layout as the one from @vrischmann but solves a problem I had with vrischmann's data reporter: It needs a new reporter per influxDB measurement. That also means with each new measurement another goroutine and another call to influxDB every x seconds.

With this metrics reporter, one is enough for all metrics and measurements in the entire application.

Unfortunately that meant breaking API changes, so I decided to write my own.