### PR TITLE
remove mutex from StandardEWMA.Tick

### DIFF
--- a/ewma_test.go
+++ b/ewma_test.go
@@ -23,7 +23,6 @@ func BenchmarkEWMAParallel(b *testing.B) {
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
 			a.Update(1)
-			a.Tick()
 		}
 	})
 }


### PR DESCRIPTION
As described in #286 , the mutex used in `StandardEWMA.Tick` should be removed to improve performance.