### PR TITLE
[feat] fix index out of range when update 

### DIFF
--- a/sample.go
+++ b/sample.go
@@ -507,7 +507,6 @@ func (s *UniformSample) Sum() int64 {
 func (s *UniformSample) Update(v int64) {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
-	s.count++
 	if len(s.values) < s.reservoirSize {
 		s.values = append(s.values, v)
 	} else {
@@ -516,6 +515,7 @@ func (s *UniformSample) Update(v int64) {
 			s.values[int(r)] = v
 		}
 	}
+	s.count++
 }
 
 // Values returns a copy of the values in the sample.


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/aa6a74fd-bc49-4741-98ca-d08f9a3d26ee)
 
When using Minio, I noticed that this lib sometimes causes an "index out of range" error. So, I traced it back to this point: rand.Int63n(s.count) can indeed cause problems under certain coincidental circumstances.